### PR TITLE
Correct gitUrl for Azure DevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ services:
   - domain: dev.azure.com
     website: "https://{{ .Service.Domain }}/{{ .Repo.Namespace }}/_git/{{ .Repo.Name }}"
     httpUrl: "https://{{ .Service.Domain }}/{{ .Repo.Namespace }}/_git/{{ .Repo.Name }}"
-    gitUrl: "git@ssh.{{ .Service.Domain }}:v3/{{ .Repo.FullName }}.git"
+    gitUrl: "git@ssh.{{ .Service.Domain }}:v3/{{ .Repo.FullName }}"
     pattern: "*/*/*"
 ```
 


### PR DESCRIPTION
Somewhat surprisingly, Azure DevOps doesn't use the `.git` extension convention for repository access over SSH.