### PR TITLE
refactor: Add support for the io.StringWriter to the output abstraction

### DIFF
--- a/internal/pkg/di/output.go
+++ b/internal/pkg/di/output.go
@@ -18,6 +18,7 @@ func SetOutput(o Output) {
 
 type Output interface {
 	io.Writer
+	io.StringWriter
 	Print(args ...interface{})
 	Println(args ...interface{})
 	Printf(format string, args ...interface{})
@@ -28,6 +29,10 @@ type StdOutput struct {
 
 func (o *StdOutput) Write(b []byte) (int, error) {
 	return os.Stdout.Write(b)
+}
+
+func (o *StdOutput) WriteString(s string) (int, error) {
+	return os.Stdout.WriteString(s)
 }
 
 func (o *StdOutput) Print(args ...interface{}) {

--- a/internal/pkg/mocks/output.go
+++ b/internal/pkg/mocks/output.go
@@ -21,6 +21,11 @@ func (o *Output) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
+func (o *Output) WriteString(s string) (int, error) {
+	o.operations = append(o.operations, s)
+	return len(s), nil
+}
+
 func (o *Output) Print(args ...interface{}) {
 	o.operations = append(o.operations, fmt.Sprint(args...))
 }


### PR DESCRIPTION
This should hopefully fix UTF-8 printing issues when using characters like `λ` (which currently appear as `?`).