### PR TITLE
Improve gitignore functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+junit.xml
+
+## -------- Managed by Git Tool -------- ##
+## Add any custom rules above this block ##
+## ------------------------------------- ##
+## @languages: go
 
 # Created by https://www.gitignore.io/api/go
 # Edit at https://www.gitignore.io/?templates=go
@@ -12,14 +18,15 @@
 
 # Test binary, built with `go test -c`
 *.test
-junit.xml
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
 
 ### Go Patch ###
 /vendor/
 /Godeps/
 
 # End of https://www.gitignore.io/api/go
-

--- a/internal/app/gitignore.go
+++ b/internal/app/gitignore.go
@@ -27,10 +27,7 @@ var getGitignoreCommand = cli.Command{
 				fmt.Fprintf(di.GetOutput(), " - %s\n", lang)
 			}
 		} else {
-			ignore, err := gitignore.Ignore(append([]string{c.Args().First()}, c.Args().Tail()...)...)
-			if err != nil {
-				return err
-			}
+			languages := append([]string{c.Args().First()}, c.Args().Tail()...)
 
 			output := di.GetOutput()
 
@@ -41,13 +38,14 @@ var getGitignoreCommand = cli.Command{
 				if err == nil {
 					if (fi.Mode() & os.ModeCharDevice) != 0 {
 						// We're outputting to a terminal, we should redirect to the .gitignore file instead
-						f, err := os.OpenFile(".gitignore", os.O_CREATE, os.ModePerm)
-						if err == nil {
-							defer f.Close()
-							output = f
-						}
+						return gitignore.AddOrUpdate(".gitignore", languages...)
 					}
 				}
+			}
+
+			ignore, err := gitignore.Ignore(languages...)
+			if err != nil {
+				return err
 			}
 
 			fmt.Fprintln(output, ignore)

--- a/internal/app/gitignore_test.go
+++ b/internal/app/gitignore_test.go
@@ -57,7 +57,7 @@ var _ = Describe("gt ignore", func() {
 		})
 	})
 
-	Context("With multiple languages provded", func() {
+	Context("With multiple languages provided", func() {
 		BeforeEach(func() {
 			err = runApp("ignore", "go", "node")
 		})

--- a/internal/pkg/gitignore/file.go
+++ b/internal/pkg/gitignore/file.go
@@ -1,0 +1,90 @@
+package gitignore
+
+import (
+	"io/ioutil"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// AddOrUpdate will add the specified languages to a gitignore file or update
+// existing entries if they are present.
+func AddOrUpdate(file string, languages ...string) error {
+	fb, err := ioutil.ReadFile(file)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return errors.Wrap(err, "gitignore: failed to open gitignore file")
+		}
+
+		fb = []byte{}
+	}
+
+	fc := string(fb)
+
+	blocks := getIgnoreBlocks(fc)
+
+	allLangsSet := map[string]struct{}{}
+	for _, lang := range languages {
+		allLangsSet[lang] = struct{}{}
+	}
+
+	for _, block := range blocks {
+		fc = strings.Replace(fc, block.Content, "", 1)
+		for _, lang := range block.Languages {
+			allLangsSet[lang] = struct{}{}
+		}
+	}
+
+	allLangs := []string{}
+	for lang := range allLangsSet {
+		allLangs = append(allLangs, lang)
+	}
+
+	ignore, err := Ignore(allLangs...)
+	if err != nil {
+		return err
+	}
+
+	fc = strings.TrimSpace(fmt.Sprintf("%s\n%s", fc, ignore))
+
+	return errors.Wrap(ioutil.WriteFile(file, []byte(fc), os.ModePerm), "gitignore: failed to write gitignore file")
+}
+
+type ignoreBlock struct {
+	Content   string
+	Languages []string
+}
+
+func getIgnoreBlocks(content string) []ignoreBlock {
+	blocks := []ignoreBlock{}
+
+	inBlock := false
+	currentContent := []string{}
+	currentLangs := []string{}
+
+	blockStartPrefix := "# Created by https://www.gitignore.io/api/"
+	blockEndPrefix := "# End of https://www.gitignore.io/api/"
+
+	for _, line := range strings.Split(content, "\n\r") {
+		if inBlock {
+			currentContent = append(currentContent, line)
+
+			if strings.HasPrefix(line, blockEndPrefix) {
+				inBlock = false
+				blocks = append(blocks, ignoreBlock{
+					Content:   strings.Join(currentContent, "\n"),
+					Languages: currentLangs,
+				})
+			}
+		} else if strings.HasPrefix(line, blockStartPrefix) {
+			currentContent = []string{line}
+			inBlock = true
+
+			currentLangs = strings.Split(line[len(blockEndPrefix):], ",")
+		}
+	}
+
+	return blocks
+}

--- a/internal/pkg/gitignore/file_test.go
+++ b/internal/pkg/gitignore/file_test.go
@@ -14,11 +14,11 @@ import (
 var _ = Describe("GitIgnore", func() {
 	Describe("AddOrUpdate()", func() {
 		var (
-			filePath string
-			languages []string
+			filePath        string
+			languages       []string
 			originalContent string
-			newContent string
-			err error
+			newContent      string
+			err             error
 		)
 
 		BeforeEach(func() {
@@ -36,13 +36,17 @@ var _ = Describe("GitIgnore", func() {
 			}
 
 			err = gitignore.AddOrUpdate(filePath, languages...)
-			
+
 			oc, ferr = ioutil.ReadFile(filePath)
 			if ferr == nil {
 				newContent = string(oc)
 			}
 		})
-		
+
+		AfterEach(func() {
+			ioutil.WriteFile(filePath, []byte(originalContent), os.ModePerm)
+		})
+
 		Context("With a file which doesn't exist", func() {
 			BeforeEach(func() {
 				filePath = test.GetTestDataPath("ignore", ".gitignore")
@@ -65,12 +69,12 @@ var _ = Describe("GitIgnore", func() {
 					Expect(newContent).To(BeEmpty())
 				})
 			})
-			
+
 			Context("With a language provided", func() {
 				BeforeEach(func() {
 					languages = []string{"go"}
 				})
-	
+
 				It("Should not report an error", func() {
 					Expect(err).To(BeNil())
 				})
@@ -84,7 +88,7 @@ var _ = Describe("GitIgnore", func() {
 				})
 			})
 		})
-		
+
 		Context("With an old file", func() {
 			BeforeEach(func() {
 				filePath = test.GetTestDataPath("ignore", "oldgo.gitignore")
@@ -104,12 +108,12 @@ var _ = Describe("GitIgnore", func() {
 					Expect(newContent).ToNot(Equal(originalContent))
 				})
 			})
-			
+
 			Context("With the same language provided", func() {
 				BeforeEach(func() {
 					languages = []string{"go"}
 				})
-	
+
 				It("Should not report an error", func() {
 					Expect(err).To(BeNil())
 				})

--- a/internal/pkg/gitignore/file_test.go
+++ b/internal/pkg/gitignore/file_test.go
@@ -1,0 +1,119 @@
+package gitignore_test
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/SierraSoftworks/git-tool/internal/pkg/gitignore"
+	"github.com/SierraSoftworks/git-tool/test"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GitIgnore", func() {
+	Describe("AddOrUpdate()", func() {
+		var (
+			filePath string
+			languages []string
+			originalContent string
+			newContent string
+			err error
+		)
+
+		BeforeEach(func() {
+			filePath = test.GetTestDataPath("ignore", "oldgo.gitignore")
+			languages = []string{}
+			originalContent = ""
+			newContent = ""
+			err = nil
+		})
+
+		JustBeforeEach(func() {
+			oc, ferr := ioutil.ReadFile(filePath)
+			if ferr == nil {
+				originalContent = string(oc)
+			}
+
+			err = gitignore.AddOrUpdate(filePath, languages...)
+			
+			oc, ferr = ioutil.ReadFile(filePath)
+			if ferr == nil {
+				newContent = string(oc)
+			}
+		})
+		
+		Context("With a file which doesn't exist", func() {
+			BeforeEach(func() {
+				filePath = test.GetTestDataPath("ignore", ".gitignore")
+			})
+
+			AfterEach(func() {
+				os.RemoveAll(filePath)
+			})
+
+			Context("With no languages provided", func() {
+				It("Should not report an error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				It("Should not start with any content", func() {
+					Expect(originalContent).To(BeEmpty())
+				})
+
+				It("Should not write any content", func() {
+					Expect(newContent).To(BeEmpty())
+				})
+			})
+			
+			Context("With a language provided", func() {
+				BeforeEach(func() {
+					languages = []string{"go"}
+				})
+	
+				It("Should not report an error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				It("Should not start with any content", func() {
+					Expect(originalContent).To(BeEmpty())
+				})
+
+				It("Should write the ignore content", func() {
+					Expect(newContent).ToNot(BeEmpty())
+				})
+			})
+		})
+		
+		Context("With an old file", func() {
+			BeforeEach(func() {
+				filePath = test.GetTestDataPath("ignore", "oldgo.gitignore")
+			})
+
+			Context("With no languages provided", func() {
+				It("Should not report an error", func() {
+					Expect(err).To(BeNil())
+				})
+
+				It("Should start with some content", func() {
+					Expect(originalContent).ToNot(BeEmpty())
+				})
+
+				It("Should write some new content", func() {
+					Expect(newContent).ToNot(BeEmpty())
+					Expect(newContent).ToNot(Equal(originalContent))
+				})
+			})
+			
+			Context("With the same language provided", func() {
+				BeforeEach(func() {
+					languages = []string{"go"}
+				})
+	
+				It("Should not report an error", func() {
+					Expect(err).To(BeNil())
+				})
+			})
+		})
+	})
+})

--- a/internal/pkg/gitignore/header.go
+++ b/internal/pkg/gitignore/header.go
@@ -1,0 +1,64 @@
+package gitignore
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ManagedFileSection struct {
+	Prologue  string
+	Languages []string
+	Content   string
+}
+
+func (h *ManagedFileSection) String() string {
+	if h.Prologue == "" && h.Content == "" && len(h.Languages) == 0 {
+		return ""
+	}
+
+	return strings.TrimSpace(strings.Join([]string{
+		h.Prologue,
+		"## -------- Managed by Git Tool -------- ##",
+		"## Add any custom rules above this block ##",
+		"## ------------------------------------- ##",
+		fmt.Sprintf("## @languages: %s", strings.Join(h.Languages, ",")),
+		h.Content,
+	}, "\n"))
+}
+
+const blockStart = "## -------- Managed by Git Tool -------- ##"
+
+func ParseSection(content string) *ManagedFileSection {
+	var section *ManagedFileSection
+
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+
+		if section == nil {
+			if line == blockStart {
+				section = &ManagedFileSection{
+					Languages: []string{},
+					Prologue:  strings.Join(lines[:i], "\n"),
+				}
+			} else {
+				continue
+			}
+		} else if !strings.HasPrefix(line, "##") {
+			section.Content = strings.Join(lines[i:], "\n")
+			break
+		}
+
+		switch true {
+		case strings.HasPrefix(line, "## @languages:"):
+			section.Languages = strings.Split(line[len("## @languages: "):], ",")
+			for i, l := range section.Languages {
+				section.Languages[i] = strings.TrimSpace(l)
+			}
+
+		default:
+		}
+	}
+
+	return section
+}

--- a/internal/pkg/gitignore/header_test.go
+++ b/internal/pkg/gitignore/header_test.go
@@ -1,0 +1,91 @@
+package gitignore_test
+
+import (
+	"strings"
+
+	"github.com/SierraSoftworks/git-tool/internal/pkg/gitignore"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("FileHeader", func() {
+	Describe("Parse()", func() {
+		var (
+			header  *gitignore.ManagedFileSection
+			content string
+		)
+
+		BeforeEach(func() {
+			content = ""
+		})
+
+		JustBeforeEach(func() {
+			header = gitignore.ParseSection(content)
+		})
+
+		Describe("When it is at the start of the file", func() {
+			BeforeEach(func() {
+				content = strings.TrimSpace(`
+## -------- Managed by Git Tool -------- ##
+## Add any custom rules above this block ##
+## ------------------------------------- ##
+## @languages: go,rust, csharp
+*.exe`)
+			})
+
+			It("should return the header", func() {
+				Expect(header).ToNot(BeNil())
+			})
+
+			It("should have the right languages", func() {
+				Expect(header).ToNot(BeNil())
+				Expect(header.Languages).To(BeEquivalentTo([]string{"go", "rust", "csharp"}))
+			})
+
+			It("should have the right prologue", func() {
+				Expect(header).ToNot(BeNil())
+				Expect(header.Prologue).To(Equal(""))
+			})
+
+			It("should have the right content", func() {
+				Expect(header).ToNot(BeNil())
+				Expect(header.Content).To(Equal("*.exe"))
+			})
+		})
+
+		Describe("When it is at the end of the file", func() {
+			BeforeEach(func() {
+				content = strings.TrimSpace(`
+junit.xml
+bin/
+
+## -------- Managed by Git Tool -------- ##
+## Add any custom rules above this block ##
+## ------------------------------------- ##
+## @languages: csharp, java
+*.exe
+*.obj`)
+			})
+
+			It("should return the header", func() {
+				Expect(header).ToNot(BeNil())
+			})
+
+			It("should have the right languages", func() {
+				Expect(header).ToNot(BeNil())
+				Expect(header.Languages).To(BeEquivalentTo([]string{"csharp", "java"}))
+			})
+
+			It("should have the right prologue", func() {
+				Expect(header).ToNot(BeNil())
+				Expect(header.Prologue).To(Equal("junit.xml\nbin/\n"))
+			})
+
+			It("should have the right content", func() {
+				Expect(header).ToNot(BeNil())
+				Expect(header.Content).To(Equal("*.exe\n*.obj"))
+			})
+		})
+	})
+})

--- a/test/data/ignore/oldgo.gitignore
+++ b/test/data/ignore/oldgo.gitignore
@@ -1,0 +1,22 @@
+# Created by https://www.gitignore.io/api/go
+# Edit at https://www.gitignore.io/?templates=go
+
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+### Go Patch ###
+/vendor/
+/Godeps/
+
+# End of https://www.gitignore.io/api/go

--- a/test/data/ignore/oldgo.gitignore
+++ b/test/data/ignore/oldgo.gitignore
@@ -1,22 +1,10 @@
-# Created by https://www.gitignore.io/api/go
-# Edit at https://www.gitignore.io/?templates=go
+## -------- Managed by Git Tool -------- ##
+## Add any custom rules above this block ##
+## ------------------------------------- ##
+## @languages: go
 
-### Go ###
-# Binaries for programs and plugins
 *.exe
 *.exe~
 *.dll
-*.so
-*.dylib
-
-# Test binary, built with `go test -c`
-*.test
-
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
-
-### Go Patch ###
-/vendor/
-/Godeps/
 
 # End of https://www.gitignore.io/api/go


### PR DESCRIPTION
# Requirements
- [x] Better handle generation of `.gitignore` files on Windows (UTF-8).
- [x] Remove the need for `> .gitignore` output piping.
- [x] Make it possible to easily update your .gitignore with a new language.
- [x] Make it possible to easily update your .gitignore file with improved definitions.
- [x] Support custom .gitignore files

This expands the `gt ignore` function to detect whether its output is being piped (`> .gitignore`) and if not, will write changes to the `.gitignore` file in the current directory.

`.gitignore` files managed by this tool will have a header injected which looks like the following:

```
## -------- Managed by Git Tool -------- ##
## Add any custom rules above this block ##
## ------------------------------------- ##
## @languages: go
```

Whenever this header is encountered, the listed `@languages` will be merged with the languages provided in `gt ignore lang1 lang2` and the content will be updated with the latest language ignore definitions.