### PR TITLE
Add shell-init command to simplify setup of shell integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.12
 require (
 	github.com/SierraSoftworks/sentry-go/v2 v2.0.0
 	github.com/SierraSoftworks/update-go v1.0.3
-	github.com/blang/semver v3.5.1+incompatible
 	github.com/danieljoos/wincred v1.0.2 // indirect
 	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/godbus/dbus v4.1.0+incompatible // indirect
@@ -19,5 +18,6 @@ require (
 	github.com/zalando/go-keyring v0.0.0-20190603084339-02404fc6afd1
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
+	golang.org/x/sys v0.0.0-20191120130536-6bfc516c8699 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,6 @@ github.com/SierraSoftworks/rates v0.0.0-20191012102625-ae684837760b h1:VSNDwumPk
 github.com/SierraSoftworks/rates v0.0.0-20191012102625-ae684837760b/go.mod h1:H5+bLeKUUDtuuYKKdLqG6A5uB8KIiY0JdVWdiJ+dWIU=
 github.com/SierraSoftworks/sentry-go/v2 v2.0.0 h1:Kvc43TTz9aEhhtYyUul5udDptrYfqbpGq4Su51JDMAE=
 github.com/SierraSoftworks/sentry-go/v2 v2.0.0/go.mod h1:dAtMCETwq4pnMMlwHVstgCDewOAFkppKSxTfi2oCsAY=
-github.com/SierraSoftworks/update-go v1.0.1 h1:EZnv98wCeXkhtX55YxIJyRLF253V5JJ5EC5N5s35Flw=
-github.com/SierraSoftworks/update-go v1.0.1/go.mod h1:F6Qx6gCw+g78pPgqjK7khhBQLhOsKixH3iWEVuB9n7s=
-github.com/SierraSoftworks/update-go v1.0.2 h1:OnHWmoEj+pRmc9eYSDB4I6sx7HfWXRopnhLkLBOjaII=
-github.com/SierraSoftworks/update-go v1.0.2/go.mod h1:F6Qx6gCw+g78pPgqjK7khhBQLhOsKixH3iWEVuB9n7s=
 github.com/SierraSoftworks/update-go v1.0.3 h1:X/AG0x/omVkCRUd48Oyf/UrcQsy9KDKrL2CgyHKn2R4=
 github.com/SierraSoftworks/update-go v1.0.3/go.mod h1:F6Qx6gCw+g78pPgqjK7khhBQLhOsKixH3iWEVuB9n7s=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
@@ -125,6 +121,8 @@ golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e h1:D5TXcfTk7xF7hvieo4QErS3qqCB4teTffacDWr7CI+0=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191120130536-6bfc516c8699 h1:oCSF9X76y260soaXqeFRu+UB7ufcanjVoUARkg8qLtc=
+golang.org/x/sys v0.0.0-20191120130536-6bfc516c8699/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -48,6 +48,7 @@ func NewApp() *cli.App {
 		openScratchCommand,
 		completeCommand,
 		updateCommand,
+		shellInitCommand,
 	}
 
 	app.Flags = []cli.Flag{

--- a/internal/app/shell_init.go
+++ b/internal/app/shell_init.go
@@ -1,0 +1,51 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/SierraSoftworks/git-tool/internal/pkg/autocomplete"
+	"github.com/SierraSoftworks/git-tool/internal/pkg/di"
+	"github.com/urfave/cli"
+)
+
+var shellInitCommand = cli.Command{
+	Name:        "shell-init",
+	Usage:       "Emits the script needed to configure your shell for use with Git-Tool.",
+	Subcommands: cli.Commands{},
+	Action: func(c *cli.Context) error {
+		if c.NArg() > 0 {
+			return nil
+		}
+
+		for _, shell := range autocomplete.GetInitScriptShells() {
+			fmt.Fprintf(di.GetOutput(), " - %s\n", shell)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	for _, shell := range autocomplete.GetInitScriptShells() {
+		shell := shell
+		shellInitCommand.Subcommands = append(shellInitCommand.Subcommands, cli.Command{
+			Name:        shell,
+			Description: fmt.Sprintf("Prints the initialization script for %s", shell),
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:   "full",
+					Hidden: true,
+				},
+			},
+			Action: func(c *cli.Context) error {
+				if !c.Bool("full") {
+					fmt.Fprint(di.GetOutput(), autocomplete.GetInitScript(shell))
+				} else {
+					fmt.Fprint(di.GetOutput(), autocomplete.GetFullInitScript(shell))
+				}
+
+				return nil
+			},
+		})
+	}
+}

--- a/internal/app/shell_init_test.go
+++ b/internal/app/shell_init_test.go
@@ -42,6 +42,12 @@ var _ = Describe("gt shell-init", func() {
 
 			Expect(out.GetOperations()).To(ContainElement(autocomplete.GetInitScript("bash")))
 		})
+
+		It("should return the full bash init script", func() {
+			Expect(runApp("shell-init", "bash", "--full")).To(BeNil())
+
+			Expect(out.GetOperations()).To(ContainElement(autocomplete.GetFullInitScript("bash")))
+		})
 	})
 
 	Context("powershell", func() {
@@ -50,6 +56,12 @@ var _ = Describe("gt shell-init", func() {
 
 			Expect(out.GetOperations()).To(ContainElement(autocomplete.GetInitScript("powershell")))
 		})
+
+		It("should return the full powershell init script", func() {
+			Expect(runApp("shell-init", "powershell", "--full")).To(BeNil())
+
+			Expect(out.GetOperations()).To(ContainElement(autocomplete.GetFullInitScript("powershell")))
+		})
 	})
 
 	Context("zsh", func() {
@@ -57,6 +69,12 @@ var _ = Describe("gt shell-init", func() {
 			Expect(runApp("shell-init", "zsh")).To(BeNil())
 
 			Expect(out.GetOperations()).To(ContainElement(autocomplete.GetInitScript("zsh")))
+		})
+
+		It("should return the full zsh init script", func() {
+			Expect(runApp("shell-init", "zsh", "--full")).To(BeNil())
+
+			Expect(out.GetOperations()).To(ContainElement(autocomplete.GetFullInitScript("zsh")))
 		})
 	})
 

--- a/internal/app/shell_init_test.go
+++ b/internal/app/shell_init_test.go
@@ -1,0 +1,80 @@
+package app_test
+
+import (
+	"github.com/SierraSoftworks/git-tool/internal/app"
+	"github.com/SierraSoftworks/git-tool/internal/pkg/autocomplete"
+	"github.com/SierraSoftworks/git-tool/internal/pkg/config"
+	"github.com/SierraSoftworks/git-tool/internal/pkg/di"
+	"github.com/SierraSoftworks/git-tool/internal/pkg/mocks"
+	"github.com/SierraSoftworks/git-tool/test"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("gt shell-init", func() {
+	var out *mocks.Output
+
+	BeforeEach(func() {
+		out = &mocks.Output{}
+		di.SetOutput(out)
+		di.SetConfig(config.DefaultForDirectory(test.GetTestPath("devdir")))
+	})
+
+	It("Should be registered with the CLI", func() {
+		Expect(app.NewApp().Command("shell-init")).ToNot(BeNil())
+	})
+
+	It("Should print out the list of shells if there is no shell provided", func() {
+		Expect(runApp("shell-init")).To(BeNil())
+
+		Expect(out.GetOperations()).To(HaveLen(len(autocomplete.GetInitScriptShells())))
+	})
+
+	It("Should print out nothing if the shell is not found", func() {
+		Expect(runApp("shell-init", "unrecognized")).To(BeNil())
+
+		Expect(out.GetOperations()).To(BeEmpty())
+	})
+
+	Context("bash", func() {
+		It("should return the bash init script", func() {
+			Expect(runApp("shell-init", "bash")).To(BeNil())
+
+			Expect(out.GetOperations()).To(ContainElement(autocomplete.GetInitScript("bash")))
+		})
+	})
+
+	Context("powershell", func() {
+		It("should return the powershell init script", func() {
+			Expect(runApp("shell-init", "powershell")).To(BeNil())
+
+			Expect(out.GetOperations()).To(ContainElement(autocomplete.GetInitScript("powershell")))
+		})
+	})
+
+	Context("zsh", func() {
+		It("should return the zsh init script", func() {
+			Expect(runApp("shell-init", "zsh")).To(BeNil())
+
+			Expect(out.GetOperations()).To(ContainElement(autocomplete.GetInitScript("zsh")))
+		})
+	})
+
+	Context("Root completion", func() {
+		It("Should appear in the completions list", func() {
+			Expect(runApp("complete", "shell-init")).To(BeNil())
+
+			Expect(out.GetOperations()).To(ContainElement("shell-init\n"))
+		})
+	})
+
+	Context("Command autocompletion", func() {
+		It("Should return the list of shells", func() {
+			Expect(runApp("complete", "gt shell-init ")).To(BeNil())
+
+			for _, shell := range autocomplete.GetInitScriptShells() {
+				Expect(out.GetOperations()).To(ContainElement(shell + "\n"))
+			}
+		})
+	})
+})

--- a/internal/pkg/autocomplete/init.go
+++ b/internal/pkg/autocomplete/init.go
@@ -1,0 +1,108 @@
+package autocomplete
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+type shell struct {
+	Name      string
+	ShortInit func() string
+	FullInit  func() string
+}
+
+func stringIdentity(input string) func() string {
+	return func() string {
+		return input
+	}
+}
+
+var shells = []shell{
+	shell{
+		Name: "powershell",
+		ShortInit: func() string {
+			return fmt.Sprintf("Invoke-Expression (@(&\"%s\" shell-init powershell --full) -join \"`n\")", os.Args[0])
+		},
+		FullInit: stringIdentity(`Register-ArgumentCompleter -CommandName gt, git-tool, git-tool.exe -ScriptBlock {
+			param([string]$commandName, [string]$wordToComplete, [int]$cursorPosition)
+		  
+			git-tool.exe complete --position $cursorPosition "$wordToComplete" | ForEach-Object {
+			  [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+			}
+		  } -Native`),
+	},
+	shell{
+		Name: "bash",
+		ShortInit: func() string {
+			return fmt.Sprintf(`if [ "${BASH_VERSINFO[0]}" -gt 4 ] || ([ "${BASH_VERSINFO[0]}" -eq 4 ] && [ "${BASH_VERSINFO[1]}" -ge 1 ])
+			then
+			source <("%s" shell-init bash --full)
+			else
+			source /dev/stdin <<<"$("%s" shell-init bash --full)"
+			fi`, os.Args[0], os.Args[0])
+		},
+		FullInit: stringIdentity(`_gittool_bash_autocomplete() {
+			local word=${COMP_WORDS[COMP_CWORD]}
+		  
+			local completions
+			completions="$(git-tool complete --position "${COMP_POINT}" "${COMP_LINE}" 2>/dev/null)"
+			if [ $? -ne 0 ]; then
+			  completions=""
+			fi
+		  
+			COMPREPLY=( $(compgen -W "$completions" -- "$word") )
+		  }
+		  
+		  complete -F _gittool_bash_autocomplete gt git-tool`),
+	},
+	shell{
+		Name: "zsh",
+		ShortInit: func() string {
+			return fmt.Sprintf(`source <("%s" shell-init zsh --full)`, os.Args[0])
+		},
+		FullInit: stringIdentity(`_gittool_zsh_autocomplete() {
+			local completions=("$(git-tool complete "$words")")
+		  
+			reply=( "${(ps:\n:)completions}" )
+		  }
+			  
+		  compdef _gittool_zsh_autocomplete gt git-tool`),
+	},
+}
+
+// GetInitScript fetches the shell initialization script for the provided shell.
+func GetInitScript(shell string) string {
+	shell = strings.ToLower(shell)
+
+	for _, s := range shells {
+		if s.Name == shell {
+			return s.ShortInit()
+		}
+	}
+
+	return ""
+}
+
+// GetFullInitScript fetches the full initialization script for the provided shell.
+func GetFullInitScript(shell string) string {
+	shell = strings.ToLower(shell)
+
+	for _, s := range shells {
+		if s.Name == shell {
+			return s.FullInit()
+		}
+	}
+
+	return ""
+}
+
+// GetInitScriptShells fetches the list of supported shells that may be initialized.
+func GetInitScriptShells() []string {
+	ss := []string{}
+	for _, s := range shells {
+		ss = append(ss, s.Name)
+	}
+
+	return ss
+}

--- a/internal/pkg/autocomplete/init_test.go
+++ b/internal/pkg/autocomplete/init_test.go
@@ -1,0 +1,87 @@
+package autocomplete_test
+
+import (
+	"fmt"
+
+	"github.com/SierraSoftworks/git-tool/internal/pkg/autocomplete"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Init", func() {
+	Describe("GetInitScript()", func() {
+		cases := []struct {
+			Shell    string
+			HasValue bool
+		}{
+			{"powershell", true},
+			{"bash", true},
+			{"zsh", true},
+			{"cmd", false},
+			{"fish", false},
+		}
+
+		for _, tc := range cases {
+			shell := tc.Shell
+			expected := tc.HasValue
+
+			Context(fmt.Sprintf("GetInitScript('%s') -> %v", tc.Shell, tc.HasValue), func() {
+				if expected {
+					It("Should have an init script", func() {
+						Expect(autocomplete.GetInitScript(shell)).ToNot(BeEmpty())
+					})
+				} else {
+					It("Should not have an init script", func() {
+						Expect(autocomplete.GetInitScript(shell)).To(BeEmpty())
+					})
+				}
+			})
+		}
+	})
+
+	Describe("GetInitScriptFull()", func() {
+		cases := []struct {
+			Shell    string
+			HasValue bool
+		}{
+			{"powershell", true},
+			{"bash", true},
+			{"zsh", true},
+			{"cmd", false},
+			{"fish", false},
+		}
+
+		for _, tc := range cases {
+			shell := tc.Shell
+			expected := tc.HasValue
+
+			Context(fmt.Sprintf("GetFullInitScript('%s') -> %v", tc.Shell, tc.HasValue), func() {
+				if expected {
+					It("Should have an init script", func() {
+						Expect(autocomplete.GetInitScript(shell)).ToNot(BeEmpty())
+					})
+				} else {
+					It("Should not have an init script", func() {
+						Expect(autocomplete.GetInitScript(shell)).To(BeEmpty())
+					})
+				}
+			})
+		}
+	})
+
+	Describe("GetInitScriptShells()", func() {
+		cases := []string{
+			"powershell",
+			"bash",
+			"zsh",
+		}
+
+		for _, tc := range cases {
+			shell := tc
+
+			It(fmt.Sprintf("Should contain %s", shell), func() {
+				Expect(autocomplete.GetInitScriptShells()).To(ContainElement(shell))
+			})
+		}
+	})
+})


### PR DESCRIPTION
- [ ] Update wiki to use the new installation instructions
- [x] Add a new `shell-init` command
- [x] Add tests for the commands
- [ ] Add the option of injecting the `gt` alias