### PR TITLE
Differentiate between critical and usage errors

### DIFF
--- a/cmd/git-tool/main.go
+++ b/cmd/git-tool/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 
 	"github.com/SierraSoftworks/git-tool/internal/app"
 	"github.com/SierraSoftworks/sentry-go/v2"
@@ -41,7 +42,12 @@ func main() {
 
 	err := app.Run(os.Args)
 	if err != nil {
-		logrus.WithError(err).Error("Unexpected error occurred")
+		if strings.HasPrefix(err.Error(), "usage: ") {
+			logrus.Error(err.Error()[len("usage: "):])
+			os.Exit(1)
+		}
+
+		logrus.WithError(err).Error()
 		raven.Capture(
 			sentry.ExceptionForError(err),
 			sentry.Level(sentry.Error),

--- a/internal/app/branch.go
+++ b/internal/app/branch.go
@@ -37,12 +37,10 @@ var branchCommand = cli.Command{
 	BashComplete: func(c *cli.Context) {
 		repo, err := di.GetMapper().GetCurrentDirectoryRepo()
 		if err != nil {
-			di.GetOutput().WriteString(err.Error())
 			return
 		}
 
 		if repo == nil {
-			di.GetOutput().WriteString("Repo not found")
 			return
 		}
 

--- a/internal/app/info.go
+++ b/internal/app/info.go
@@ -29,9 +29,9 @@ var repoInfoCommand = cli.Command{
 		}
 
 		if repo == nil && c.NArg() == 0 {
-			return errors.New("no repository specified")
+			return errors.New("usage: no repository specified")
 		} else if repo == nil {
-			return errors.New("could not find repository")
+			return errors.New("usage: could not find repository")
 		}
 
 		fmt.Fprintln(di.GetOutput(), templates.RepoFullInfo(repo))

--- a/internal/app/info_test.go
+++ b/internal/app/info_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/SierraSoftworks/git-tool/internal/app"
 	"github.com/SierraSoftworks/git-tool/internal/pkg/config"
 	"github.com/SierraSoftworks/git-tool/internal/pkg/di"
-	"github.com/SierraSoftworks/git-tool/internal/pkg/templates"
 	"github.com/SierraSoftworks/git-tool/internal/pkg/mocks"
+	"github.com/SierraSoftworks/git-tool/internal/pkg/templates"
 	"github.com/SierraSoftworks/git-tool/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -48,7 +48,7 @@ var _ = Describe("gt info", func() {
 			})
 
 			It("Should inform the user in the error of why the command failed", func() {
-				Expect(err.Error()).To(Equal("no repository specified"))
+				Expect(err.Error()).To(Equal("usage: no repository specified"))
 			})
 
 			It("Should not print any output", func() {
@@ -103,7 +103,7 @@ var _ = Describe("gt info", func() {
 		})
 
 		It("Should inform the user in the error of why the command failed", func() {
-			Expect(err.Error()).To(Equal("could not find repository"))
+			Expect(err.Error()).To(Equal("usage: could not find repository"))
 		})
 
 		It("Should not print any output", func() {

--- a/internal/app/new.go
+++ b/internal/app/new.go
@@ -21,7 +21,7 @@ var newRepoCommand = cli.Command{
 		defer tracing.Exit()
 
 		if c.NArg() == 0 {
-			return errors.New("no repository specified")
+			return errors.New("usage: no repository specified")
 		}
 
 		r, err := di.GetMapper().GetRepo(c.Args().First())
@@ -30,7 +30,7 @@ var newRepoCommand = cli.Command{
 		}
 
 		if r == nil {
-			return errors.New("not a valid repository name")
+			return errors.New("usage: not a valid repository name")
 		}
 
 		init := di.GetInitializer()

--- a/internal/app/new_test.go
+++ b/internal/app/new_test.go
@@ -39,7 +39,7 @@ var _ = Describe("gt new", func() {
 		})
 
 		It("Should inform the user in the error of why the command failed", func() {
-			Expect(err.Error()).To(Equal("no repository specified"))
+			Expect(err.Error()).To(Equal("usage: no repository specified"))
 		})
 
 		It("Should not print any output", func() {
@@ -105,7 +105,7 @@ var _ = Describe("gt new", func() {
 		})
 
 		It("Should inform the user in the error of why the command failed", func() {
-			Expect(err.Error()).To(Equal("not a valid repository name"))
+			Expect(err.Error()).To(Equal("usage: not a valid repository name"))
 		})
 
 		It("Should not print any output", func() {

--- a/internal/app/open.go
+++ b/internal/app/open.go
@@ -33,9 +33,9 @@ var openAppCommand = cli.Command{
 		}
 
 		if app == nil && c.NArg() > 0 {
-			return errors.Errorf("no app called %s in your config", c.Args().First())
+			return errors.Errorf("usage: no app called %s in your config", c.Args().First())
 		} else if app == nil {
-			return errors.Errorf("no apps in your config")
+			return errors.Errorf("usage: no apps in your config")
 		}
 
 		logrus.WithField("app", app.Name()).Debug("Found matching app configuration")
@@ -46,9 +46,9 @@ var openAppCommand = cli.Command{
 		}
 
 		if r == nil && len(args) == 0 {
-			return errors.New("no repository specified")
+			return errors.New("usage: no repository specified")
 		} else if r == nil {
-			return errors.New("could not find repository")
+			return errors.New("usage: could not find repository")
 		}
 
 		if !r.Exists() {
@@ -58,7 +58,7 @@ var openAppCommand = cli.Command{
 			err := init.CloneRepository(r)
 			if err != nil {
 				logrus.WithError(err).Error("Failed to clone repository")
-				return errors.New("repository doesn't exist yet, use 'new' to create it")
+				return errors.New("usage: repository doesn't exist yet, use 'new' to create it")
 			}
 		}
 

--- a/internal/app/open_test.go
+++ b/internal/app/open_test.go
@@ -49,7 +49,7 @@ var _ = Describe("gt open", func() {
 			})
 
 			It("Should inform the user in the error of why the command failed", func() {
-				Expect(err.Error()).To(Equal("no repository specified"))
+				Expect(err.Error()).To(Equal("usage: no repository specified"))
 			})
 
 			It("Should not print any output", func() {
@@ -167,7 +167,7 @@ var _ = Describe("gt open", func() {
 			})
 
 			It("Should inform the user in the error of why the command failed", func() {
-				Expect(err.Error()).To(Equal("no repository specified"))
+				Expect(err.Error()).To(Equal("usage: no repository specified"))
 			})
 
 			It("Should not print any output", func() {
@@ -244,7 +244,7 @@ var _ = Describe("gt open", func() {
 		})
 
 		It("Should inform the user in the error of why the command failed", func() {
-			Expect(err.Error()).To(Equal("could not find repository"))
+			Expect(err.Error()).To(Equal("usage: could not find repository"))
 		})
 
 		It("Should not print any output", func() {

--- a/internal/app/scratch.go
+++ b/internal/app/scratch.go
@@ -35,9 +35,9 @@ var openScratchCommand = cli.Command{
 		}
 
 		if app == nil && c.NArg() > 0 {
-			return errors.Errorf("no app called %s in your config", c.Args().First())
+			return errors.Errorf("usage: no app called %s in your config", c.Args().First())
 		} else if app == nil {
-			return errors.Errorf("no apps in your config")
+			return errors.Errorf("usage: no apps in your config")
 		}
 
 		logrus.WithField("app", app.Name()).Debug("Found matching app configuration")

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -55,7 +55,7 @@ var updateCommand = cli.Command{
 			}
 
 			if targetRelease == nil {
-				return fmt.Errorf("could not find update with provided tag")
+				return fmt.Errorf("usage: could not find update with provided tag")
 			}
 		} else {
 			currentVersion := c.App.Version


### PR DESCRIPTION
### Description
When reporting errors to the user, we should differentiate between fatal and non-fatal errors and only focus on reporting fatal ones as "errors" while the remainder are advisories or cautions.

### Expected behavior
When an error like a "repository not found" is encountered, we should not treat that as a critical problem with the program.
