### PR TITLE
Automatically checkout remote branches if they exist

### DIFF
--- a/internal/app/branch.go
+++ b/internal/app/branch.go
@@ -32,7 +32,7 @@ var branchCommand = cli.Command{
 			return errors.New("usage: command requires a branch to be provided")
 		}
 
-		return tasks.GitCheckout(c.Args().First()).ApplyRepo(repo)
+		return tasks.GitCheckout(c.Args().First(), false).ApplyRepo(repo)
 	},
 	BashComplete: func(c *cli.Context) {
 		repo, err := di.GetMapper().GetCurrentDirectoryRepo()

--- a/internal/app/branch_test.go
+++ b/internal/app/branch_test.go
@@ -36,7 +36,7 @@ var _ = Describe("gt branch", func() {
 			tasks.GitInit(),
 			tasks.NewFile("README.md", []byte("# Test Repo")),
 			tasks.GitCommit("Initial Commit", "README.md"),
-			tasks.GitCheckout("master"),
+			tasks.GitCheckout("master", false),
 		).ApplyRepo(repo)
 		if err != nil {
 			return

--- a/internal/pkg/tasks/gitcheckout.go
+++ b/internal/pkg/tasks/gitcheckout.go
@@ -46,7 +46,7 @@ func (t *gitCheckout) ApplyRepo(r models.Repo) error {
 			return nil
 		}
 
-		if r.Name().Short() == t.RefName {
+		if r.Name().Short() == t.RefName || r.Name().Short() == "origin/"+t.RefName {
 			if ref == nil {
 				ref = r
 			} else if ref.Name().IsRemote() && !r.Name().IsRemote() {

--- a/internal/pkg/tasks/gitcheckout_test.go
+++ b/internal/pkg/tasks/gitcheckout_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Git Checkout Task", func() {
 	Describe("GitCheckout()", func() {
 		Context("when applied to a repo", func() {
 			JustBeforeEach(func() {
-				err = tasks.GitCheckout(ref).ApplyRepo(r)
+				err = tasks.GitCheckout(ref, false).ApplyRepo(r)
 			})
 
 			Context("which doesn't exist locally", func() {
@@ -97,7 +97,7 @@ var _ = Describe("Git Checkout Task", func() {
 						tasks.GitInit(),
 						tasks.NewFile("README.md", []byte("# Test Repo")),
 						tasks.GitCommit("Initial Commit", "README.md"),
-						tasks.GitCheckout("master"),
+						tasks.GitCheckout("master", false),
 					).ApplyRepo(r)
 				})
 

--- a/internal/pkg/tasks/gitnewref.go
+++ b/internal/pkg/tasks/gitnewref.go
@@ -1,0 +1,50 @@
+package tasks
+
+import (
+	"github.com/SierraSoftworks/git-tool/pkg/models"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+)
+
+// GitNewRef is responsible for creating a new Git reference which points at HEAD.
+func GitNewRef(name string) Task {
+	return &gitNewRef{
+		Name: name,
+	}
+}
+
+// gitCommit is responsible for creating a new git reference which points at HEAD.
+type gitNewRef struct {
+	Name string
+}
+
+// ApplyRepo runs the task against a repository
+func (t *gitNewRef) ApplyRepo(r models.Repo) error {
+	gr, err := git.PlainOpen(r.Path())
+	if err != nil {
+		return errors.Wrap(err, "repo: unable to open git repository")
+	}
+
+	head, err := gr.Head()
+	if err != nil {
+		return errors.Wrap(err, "repo: unable to get repo HEAD")
+	}
+
+	ref := plumbing.NewHashReference(plumbing.ReferenceName(t.Name), head.Hash())
+
+	logrus.WithField("repo", r).WithField("ref", t.Name).Debugf("Creating new git ref")
+	err = gr.Storer.SetReference(ref)
+
+	if err != nil {
+		return errors.Wrap(err, "repo: unable to create git ref")
+	}
+
+	return nil
+}
+
+// ApplyScratchpad runs the task against a scratchpad
+func (t *gitNewRef) ApplyScratchpad(r models.Scratchpad) error {
+	return nil
+}


### PR DESCRIPTION
This PR fixes #24 by ensuring that if a remote branch with the same name already exists, it will be checked out.