### PR TITLE
fix: Use Sentry symbolicator for debug info and return to release builds

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -4,31 +4,44 @@ on:
     types: [published]
 jobs:
   version:
-    name: Calculate Version
+    name: Start Release
     runs-on: ubuntu-latest
-  
+
     steps:
-    - name: Check out code
-      uses: actions/checkout@v2
+      - name: Setup Sentry CLI
+        uses: mathrix-education/setup-sentry-cli@0.1.1
+        with:
+          token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          organization: sierra-softworks
+          project: git-tool
 
-    - name: Generate Package Version
-      id: version
-      shell: pwsh
-      run: Write-Host "::set-output name=version::$('${{ github.event.release.tag_name }}'.substring(1))"
+      - name: Check out code
+        uses: actions/checkout@v2
 
-    - name: Set Package Version
-      uses: ciiiii/toml-editor@1.0.0
-      with:
-        file: Cargo.toml
-        key: package.version
-        value: ${{ steps.version.outputs.version }}
+      - name: Create Sentry Release
+        run: |
+          VERSION="git-tool@${{ github.event.release.tag_name }}"
+          sentry-cli releases new "$VERSION"
+          sentry-cli releases set-commits "$VERSION" --auto
 
-    - name: Stash Versioned Cargo.toml
-      uses: actions/upload-artifact@v2
-      with:
-        name: cargofile
-        path: Cargo.toml
-    
+      - name: Generate Package Version
+        id: version
+        shell: pwsh
+        run: Write-Host "::set-output name=version::$('${{ github.event.release.tag_name }}'.substring(1))"
+
+      - name: Set Package Version
+        uses: ciiiii/toml-editor@1.0.0
+        with:
+          file: Cargo.toml
+          key: package.version
+          value: ${{ steps.version.outputs.version }}
+
+      - name: Stash Versioned Cargo.toml
+        uses: actions/upload-artifact@v2
+        with:
+          name: cargofile
+          path: Cargo.toml
+
   build:
     name: Build
     runs-on: ${{ matrix.os }}
@@ -49,47 +62,66 @@ jobs:
             os: macos-latest
 
     steps:
-    - name: Install Dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install libdbus-1-3 libdbus-1-dev
-      if: matrix.os_name == 'linux'
-      
-    - name: Get Rust Stable
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libdbus-1-3 libdbus-1-dev
+        if: matrix.os_name == 'linux'
 
-    - name: Check out code
-      uses: actions/checkout@v2
+      - name: Get Rust Stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
 
-    - name: Fetch Versioned Cargo.toml
-      uses: actions/download-artifact@v2
-      with:
-        name: cargofile
+      - name: Setup Sentry CLI
+        uses: mathrix-education/setup-sentry-cli@0.1.1
+        with:
+          token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          organization: sierra-softworks
+          project: git-tool
 
-    - name: Build Release
-      uses: actions-rs/cargo@v1.0.3
-      with:
-        command: build
-        args: --release
-        
-    - name: Create Sentry Release
-      uses: tclindner/sentry-releases-action@v1.2.0
-      env:
-        SENTRY_ORG: sierra-softworks
-        SENTRY_PROJECT: git-tool
-        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      with:
-        environment: git-tool
-        tagName: git-tool@${{ github.event.release.tag_name }}
-      if: matrix.os_name == 'linux'
+      - name: Check out code
+        uses: actions/checkout@v2
 
-    - name: Upload to Release
-      uses: Shopify/upload-to-release@1.0.0
-      with:
-        name: "git-tool-${{ matrix.os_name }}-${{ matrix.arch }}${{ matrix.extension }}"
-        path: "target/release/git-tool${{ matrix.extension }}"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        content-type: application/octet-stream
+      - name: Fetch Versioned Cargo.toml
+        uses: actions/download-artifact@v2
+        with:
+          name: cargofile
+
+      - name: Build Release
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: build
+          args: --release
+
+      - name: Upload to Release
+        uses: Shopify/upload-to-release@1.0.0
+        with:
+          name: "git-tool-${{ matrix.os_name }}-${{ matrix.arch }}${{ matrix.extension }}"
+          path: "target/release/git-tool${{ matrix.extension }}"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          content-type: application/octet-stream
+
+      - name: Upload Debug Symbols to Sentry
+        run: |
+          sentry-cli upload-dif -o sierra-softworks -p git-tool --include-sources ./target/release
+
+  sentry:
+    name: Finalize Release
+    runs-on: ubuntu-latest
+    needs:
+      - version
+      - build
+
+    steps:
+      - name: Setup Sentry CLI
+        uses: mathrix-education/setup-sentry-cli@0.1.1
+        with:
+          token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          organization: sierra-softworks
+          project: git-tool
+
+      - name: Finalize Sentry Release
+        run: |
+          sentry-cli releases finalize "$VERSION"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,3 @@ serde_yaml = "0.8"
 shell-words = "1.0"
 tempfile = "3.1"
 tokio = { version = "0.2", features = ["full"] }
-
-[profile.release]
-debug = true


### PR DESCRIPTION
Fixes #81