### PR TITLE
fix: Prevent Git-Tool from intercepting signals intended for child processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "futures",
  "gtmpl",
  "http",
  "hyper",
@@ -542,6 +543,7 @@ dependencies = [
  "itertools 0.9.0",
  "keyring",
  "log",
+ "nix",
  "rpassword",
  "semver 0.10.0",
  "sentry",
@@ -764,6 +766,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
+
+[[package]]
 name = "itertools"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,9 +797,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.42"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52732a3d3ad72c58ad2dc70624f9c17b46ecd0943b9a4f1ee37c4c18c5d983e2"
+checksum = "85a7e2c92a4804dd459b86c339278d0fe87cf93757fae222c3fa3ae75458bc73"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -826,9 +834,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7d4bd64732af4bf3a67f367c27df8520ad7e230c5817b8ff485864d80242b9"
+checksum = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
 
 [[package]]
 name = "linked-hash-map"
@@ -979,6 +987,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "nix"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1139,18 +1159,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e3a6cdbfe94a5e4572812a0201f8c0ed98c1c452c7b8563ce2276988ef9c17"
+checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
+checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1209,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.16"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
+checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
 name = "proc-macro-nested"
@@ -1221,9 +1241,9 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
+checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
  "unicode-xid",
 ]
@@ -1437,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b82c9238b305f26f53443e3a4bc8528d64b8d0bee408ec949eb7bf5635ec680"
+checksum = "12427a5577082c24419c9c417db35cfeb65962efc7675bb6b0d5f1f9d315bfe6"
 dependencies = [
  "base64",
  "bytes",
@@ -1450,6 +1470,7 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-tls",
+ "ipnet",
  "js-sys",
  "lazy_static",
  "log",
@@ -1698,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
+checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
 dependencies = [
  "itoa",
  "ryu",
@@ -1801,9 +1822,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
-version = "1.0.34"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cae2873c940d92e697597c5eee105fb570cd5689c695806f672883653349b"
+checksum = "4cdb98bcb1f9d81d07b536179c269ea15999b5d14ea958196413869445bb5250"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1912,9 +1933,9 @@ checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
 
 [[package]]
 name = "tokio"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
+checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
 dependencies = [
  "bytes",
  "fnv",
@@ -1977,9 +1998,9 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e2a2de6b0d5cbb13fc21193a2296888eaab62b6044479aafb3c54c01c29fcd"
+checksum = "dbdf4ccd1652592b01286a5dbe1e2a77d78afaa34beadd9872a5f7396f92aaa9"
 dependencies = [
  "cfg-if",
  "log",
@@ -2119,9 +2140,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.65"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edbcc9536ab7eababcc6d2374a0b7bfe13a2b6d562c5e07f370456b1a8f33d"
+checksum = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
 dependencies = [
  "cfg-if",
  "serde",
@@ -2131,9 +2152,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.65"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ed2fb8c84bfad20ea66b26a3743f3e7ba8735a69fe7d95118c33ec8fc1244d"
+checksum = "bc71e4c5efa60fb9e74160e89b93353bc24059999c0ae0fb03affc39770310b0"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2146,9 +2167,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.15"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ad6e4e8b2b7f8c90b6e09a9b590ea15cb0d1dbe28502b5a405cd95d1981671"
+checksum = "95f8d235a77f880bcef268d379810ea6c0af2eacfa90b1ad5af731776e0c4699"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2158,9 +2179,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.65"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb071268b031a64d92fc6cf691715ca5a40950694d8f683c5bb43db7c730929e"
+checksum = "97c57cefa5fa80e2ba15641578b44d36e7a64279bc5ed43c6dbaf329457a2ed2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2168,9 +2189,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.65"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf592c807080719d1ff2f245a687cbadb3ed28b2077ed7084b47aba8b691f2c6"
+checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2181,15 +2202,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.65"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b6c0220ded549d63860c78c38f3bcc558d1ca3f4efa74942c536ddbbb55e87"
+checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
 
 [[package]]
 name = "web-sys"
-version = "0.3.42"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be2398f326b7ba09815d0b403095f34dd708579220d099caae89be0b32137b2"
+checksum = "dda38f4e5ca63eda02c059d243aa25b5f35ab98451e518c51612cd0f1bd19a47"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,15 @@ async-trait = "0.1"
 base64 = "0.12"
 chrono = "0.4"
 clap = "3.0.0-beta.1"
+futures = "0.3.5"
 gtmpl = "0.5"
 http = "0.2"
 hyper = "0.13"
-yup-hyper-mock = "4.0"
 hyper-tls = "0.4"
 itertools = "0.9"
 keyring = "0.9"
 log = "0.4"
+nix = "0.18.0"
 rpassword = "4.0"
 semver = "0.10"
 sentry = { version = "0.19", features = ["log", "test"] }
@@ -28,6 +29,7 @@ serde_yaml = "0.8"
 shell-words = "1.0"
 tempfile = "3.1"
 tokio = { version = "0.2", features = ["full"] }
+yup-hyper-mock = "4.0"
 
 [profile.release]
 debug = true

--- a/src/core/launcher.rs
+++ b/src/core/launcher.rs
@@ -5,7 +5,8 @@ use super::{
     Config, Target,
 };
 use async_trait::async_trait;
-use std::sync::Arc;
+use futures::{pin_mut, select, FutureExt};
+use std::{convert::TryInto, sync::Arc};
 use tokio::process::Command;
 
 #[async_trait]
@@ -38,14 +39,75 @@ impl Launcher for TokioLauncher {
             .map(|i| i.split("=").collect())
             .map(|i: Vec<&str>| (i[0], i[1]));
 
-        let status = Command::new(program)
+        let mut child = Command::new(program)
             .args(args)
             .current_dir(t.get_path())
             .envs(env_arg_tuples)
-            .spawn()?
-            .await?;
+            .spawn()?;
 
-        Ok(status.code().unwrap_or_default())
+        self.forward_signals(&mut child).await
+    }
+}
+
+impl TokioLauncher {
+    #[cfg(windows)]
+    async fn forward_signals(&self, child: &mut tokio::process::Child) -> Result<i32, Error> {
+        let fused_child = child.fuse();
+        pin_mut!(fused_child);
+
+        loop {
+            let ctrlc = tokio::signal::ctrl_c().fuse();
+            pin_mut!(ctrlc);
+
+            select! {
+                _ = ctrlc => {
+                    // We capture the Ctrl+C signal and ignore it so that the child process
+                    // can handle it as necessary.
+                },
+                status = fused_child => {
+                    return Ok(status?.code().unwrap_or_default());
+                }
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    async fn forward_signals(&self, child: &mut tokio::process::Child) -> Result<i32, Error> {
+        let pid = nix::unistd::Pid::from_raw(child.id().try_into().map_err(|err| crate::errors::system_with_internal(
+            "Unable to convert child process ID to a valid PID. This may impact Git-Tool's ability to forward signals to a child application.",
+            "Please report this error to us on GitHub, along with information about your operating system and version of Git-Tool, so that we can investigate further.",
+            err))?);
+        let fused_child = child.fuse();
+
+        let mut sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())?;
+        let mut sigterm =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+        let mut sigquit = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::quit())?;
+
+        pin_mut!(fused_child);
+
+        loop {
+            let sigint = sigint.recv().fuse();
+            let sigterm = sigterm.recv().fuse();
+            let sigquit = sigquit.recv().fuse();
+
+            pin_mut!(sigint, sigterm, sigquit);
+
+            select! {
+                _ = sigint => {
+                    nix::sys::signal::kill(pid, nix::sys::signal::Signal::SIGINT)?;
+                },
+                _ = sigterm => {
+                    nix::sys::signal::kill(pid, nix::sys::signal::Signal::SIGTERM)?;
+                },
+                _ = sigquit => {
+                    nix::sys::signal::kill(pid, nix::sys::signal::Signal::SIGQUIT)?;
+                },
+                status = fused_child => {
+                    return Ok(status?.code().unwrap_or_default())
+                }
+            }
+        }
     }
 }
 

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -3,6 +3,8 @@ use std::{error, fmt};
 mod base64;
 pub mod hyper;
 mod keyring;
+#[cfg(unix)]
+mod nix;
 mod serde;
 mod std_io;
 mod utf8;

--- a/src/errors/nix.rs
+++ b/src/errors/nix.rs
@@ -1,0 +1,10 @@
+use super::{system_with_internal, Error};
+
+impl std::convert::From<nix::Error> for Error {
+    fn from(err: nix::Error) -> Self {
+        system_with_internal(
+            "We could not send a signal to the child process correctly. This may impact the way Git-Tool responds to interrupts and termination signals.",
+            "Please let us know what happened on GitHub so that we can help resolve the issue for you. Ensure that you provide us with information on your operating system and the version of Git-Tool you're running.",
+            err)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 .env("GITTOOL_CONFIG")
                 .value_name("FILE")
                 .about("The path to your git-tool configuration file.")
-                .global(true)
                 .takes_value(true))
         .arg(Arg::with_name("update-resume-internal")
             .long("update-resume-internal")


### PR DESCRIPTION
Fixes #94