### PR TITLE
fix: remove conflicting switch short alias

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "git-tool"
 version = "0.2.0"
-authors = ["Benjamin Pannell <benjamin@pannell.dev>"]
+authors = ["Benjamin Pannell <benjamin@pannell.dev>", "Aideen Fay <me@aideen.dev>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/commands/switch.rs
+++ b/src/commands/switch.rs
@@ -15,7 +15,6 @@ impl Command for SwitchCommand {
     fn app<'a>(&self) -> App<'a> {
         App::new(self.name().as_str())
             .version("1.0")
-            .alias("s")
             .about("switches to the specified branch.")
             .long_about(
                 "This command switches to the specified branch within the current repository.",


### PR DESCRIPTION
Removes the short alias "_s_" for switch that conflicts with the alias for scratchpad.