### PR TITLE
zsh fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Then add the following:
 
 ```bash
 # ~/.bashrc
-alias gt="git-tool"
+alias gt="git-tool --config /your/path/to/git-tool.yml"
 eval "$(git-tool shell-init bash)"
 ```
 
@@ -119,7 +119,7 @@ Then add the following:
 
 ```zsh
 # ~/.zshrc
-alias gt="git-tool"
+alias gt="git-tool --config /your/path/to/git-tool.yml"
 eval "$(git-tool shell-init zsh)"
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # Git Tool
+
 **Simplify checking out your Git repositories in a structured directory space**
 
 Git Tool is a powerful tool for managing your Git repositories, storing them in
 a consistent folder structure and simplifying access when you need it.
 
 ## Features
- - **Quickly open repositories** whether they are already cloned locally or not, using your favourite Git services and a concise folder structure.
- - **Launch applications** within the context of your repositories quickly and consistently.
- - **Weekly scratchpads** to help organize random work and doodles with minimal effort.
- - **Aliases** to make opening your most common repositories as quick as possible.
- - **Fast autocompletion** on all platforms with support for "sequence search" (`ssgt` matches `SierraSoftworks/git-tool`) as found in Sublime and VSCode.
+
+- **Quickly open repositories** whether they are already cloned locally or not, using your favourite Git services and a concise folder structure.
+- **Launch applications** within the context of your repositories quickly and consistently.
+- **Weekly scratchpads** to help organize random work and doodles with minimal effort.
+- **Aliases** to make opening your most common repositories as quick as possible.
+- **Fast autocompletion** on all platforms with support for "sequence search" (`ssgt` matches `SierraSoftworks/git-tool`) as found in Sublime and VSCode.
 
 ## Example
 
@@ -38,6 +40,7 @@ gt s
 ## Installation
 
 #### Step 1: Download the latest Release
+
 Make sure you download the latest [release][] for your platform and place it in a directory on your `$PATH`.
 
 #### Step 2: Ensure that you can run `git-tool`
@@ -48,6 +51,7 @@ gt version 1.2.13+1
 ```
 
 #### Step 3: Configure your Installation
+
 Add a `git-config.yml` file somewhere and fill it in with the following (modifying your directory to match your chosen development folder).
 
 ```yaml
@@ -73,6 +77,7 @@ apps:
 Then update your environment to inform `git-tool` of your config file. While you're at it, enable autocomplete.
 
 ##### Windows
+
 ```powershell
 notepad $PROFILE.CurrentUserAllHosts
 ```
@@ -91,6 +96,7 @@ Invoke-Expression (&git-tool shell-init powershell)
 ```
 
 ##### Linux
+
 ```bash
 vi ~/.bashrc
 ```
@@ -100,10 +106,11 @@ Then add the following:
 ```bash
 # ~/.bashrc
 alias gt="git-tool"
-eval "$(git-ignore shell-init bash)"
+eval "$(git-tool shell-init bash)"
 ```
 
 ##### MacOS
+
 ```zsh
 vi ~/.zshrc
 ```
@@ -113,13 +120,15 @@ Then add the following:
 ```zsh
 # ~/.zshrc
 alias gt="git-tool"
-eval "$(git-ignore shell-init zsh)"
+eval "$(git-tool shell-init zsh)"
 ```
 
 ## Adding new Services
+
 Git Tool has been written to support a wide range of Git servers and allows you to add your own via the config file.
 
 #### Azure DevOps
+
 ```yaml
 services:
   - domain: dev.azure.com
@@ -130,6 +139,7 @@ services:
 ```
 
 #### BitBucket
+
 ```yaml
 services:
   - domain: bitbucket.org
@@ -140,6 +150,7 @@ services:
 ```
 
 #### GitLab
+
 ```yaml
 services:
   - domain: gitlab.com
@@ -150,17 +161,20 @@ services:
 ```
 
 #### Custom
+
 When adding a custom service, you will need to ensure that you provide the various templates necessary for generating URLs
 as well as the glob `pattern` which will be used to identify repositories within the service's development directory. In
 the case of most Git services, this will be `*/*` (corresponding to the organization name and repository name); however some
 services like Azure DevOps make use of different patterns.
 
 ## Adding new Apps
+
 Git Tool has the ability to launch applications within the context of your repositories. This is useful when you want to
 quickly open a shell or your favourite editor and start working, however you can also add a wide range of other applications
 there. Here are a few examples.
 
 #### Admin PowerShell on Windows
+
 ```yaml
 apps:
   - name: admin
@@ -174,6 +188,7 @@ apps:
 ```
 
 #### Windows Explorer
+
 ```yaml
 apps:
   - name: explorer
@@ -183,12 +198,13 @@ apps:
 ```
 
 ## Aliases
+
 For your most common repositories, it can often make sense to give distinct aliases. These aliases allow you to quickly and
 exactly specify a repository without typing its full name or relying on autocomplete.
 
 ```yaml
 aliases:
-    blog: github.com/sierrasoftworks/blog
+  blog: github.com/sierrasoftworks/blog
 ```
 
 You can use an alias anywhere you would specify a repository name, such as `gt o blog`.

--- a/src/completion/setup.rs
+++ b/src/completion/setup.rs
@@ -76,7 +76,7 @@ complete -F _gittool_bash_autocomplete gt git-tool
         Shell {
             name: "zsh".into(),
             short_init: format!(
-                r#"source <("{app}" shell-init zsh --full"#,
+                r#"source <("{app}" shell-init zsh --full)"#,
                 app = args().next().unwrap_or("git-tool".to_string())
             ),
             long_init: format!(


### PR DESCRIPTION
- Replace 'git-ignore' in shell integration scripts with 'git-tool'
- Add missing ')' to zsh shell init script

Please note that the actual completions don't seem to work for ZSH yet (at least on MacOS with oh-my-zsh), but it's nothing I want to get into just yet 😅.
