### PR TITLE
Improve "not a valid repo" error messages when running `gt info`

### DIFF
--- a/src/core/launcher.rs
+++ b/src/core/launcher.rs
@@ -152,6 +152,7 @@ pub mod mocks {
                     "Mock Error".to_string(),
                     "Configure the mock to not throw an error".to_string(),
                     None,
+                    None,
                 ))
             } else {
                 Ok(self.status)

--- a/src/core/resolver.rs
+++ b/src/core/resolver.rs
@@ -62,7 +62,7 @@ impl Resolver for FileSystemResolver {
 
         match self.get_repo(&cwd) {
             Ok(repo) => Ok(repo),
-            Err(e) => Err(errors::user_with_internal(
+            Err(e) => Err(errors::user_with_cause(
                 &format!("Current directory ('{}') is not a valid repository.", cwd.display()),
                 &format!("Make sure that you are currently within a repository contained within your development directory ('{}').", self.config.get_dev_directory().canonicalize()?.display()),
                 e))
@@ -225,12 +225,17 @@ fn repo_from_relative_path<'a>(
     if name_parts.len() != name_length {
         Err(errors::user(
             &format!(
-                "The service '{}' requires a repository name in the form '{}', but we got '{}'.",
+                "The service '{}' requires a repository name in the form '{}/{}', but you provided '{}'.",
+                svc.get_domain(),
                 svc.get_domain(),
                 svc.get_pattern(),
                 relative_path.display()
             ),
-            "Make sure that your repository is correctly named for the service you are using.",
+            &format!(
+                "Make sure that you are using a repository name which looks like '{}/{}'.",
+                svc.get_domain(),
+                svc.get_pattern()
+            ),
         ))
     } else {
         Ok(Repo::new(
@@ -321,6 +326,7 @@ pub mod mocks {
                     "Mock Error".to_string(),
                     "Configure the mock to not throw an error".to_string(),
                     None,
+                    None,
                 )),
                 false => Ok(self.scratchpads.clone()),
             }
@@ -360,6 +366,7 @@ pub mod mocks {
                     "Mock Error".to_string(),
                     "Configure the mock to not throw an error".to_string(),
                     None,
+                    None,
                 )),
                 false => Ok(self.repos.clone()),
             }
@@ -370,6 +377,7 @@ pub mod mocks {
                 true => Err(Error::SystemError(
                     "Mock Error".to_string(),
                     "Configure the mock to not throw an error".to_string(),
+                    None,
                     None,
                 )),
                 false => Ok(self

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -11,12 +11,31 @@ mod utf8;
 
 #[derive(Debug)]
 pub enum Error {
-    UserError(String, String, Option<Box<dyn error::Error + Send + Sync>>),
-    SystemError(String, String, Option<Box<dyn error::Error + Send + Sync>>),
+    UserError(
+        String,
+        String,
+        Option<Box<Error>>,
+        Option<Box<dyn error::Error + Send + Sync>>,
+    ),
+    SystemError(
+        String,
+        String,
+        Option<Box<Error>>,
+        Option<Box<dyn error::Error + Send + Sync>>,
+    ),
 }
 
 pub fn user(description: &str, advice: &str) -> Error {
-    Error::UserError(description.to_string(), advice.to_string(), None)
+    Error::UserError(description.to_string(), advice.to_string(), None, None)
+}
+
+pub fn user_with_cause(description: &str, advice: &str, cause: Error) -> Error {
+    Error::UserError(
+        description.to_string(),
+        advice.to_string(),
+        Some(Box::from(cause)),
+        None,
+    )
 }
 
 pub fn user_with_internal<T>(description: &str, advice: &str, internal: T) -> Error
@@ -26,12 +45,22 @@ where
     Error::UserError(
         description.to_string(),
         advice.to_string(),
+        None,
         Some(internal.into()),
     )
 }
 
 pub fn system(description: &str, advice: &str) -> Error {
-    Error::SystemError(description.to_string(), advice.to_string(), None)
+    Error::SystemError(description.to_string(), advice.to_string(), None, None)
+}
+
+pub fn system_with_cause(description: &str, advice: &str, cause: Error) -> Error {
+    Error::SystemError(
+        description.to_string(),
+        advice.to_string(),
+        Some(Box::from(cause)),
+        None,
+    )
 }
 
 pub fn system_with_internal<T>(description: &str, advice: &str, internal: T) -> Error
@@ -41,27 +70,82 @@ where
     Error::SystemError(
         description.to_string(),
         advice.to_string(),
+        None,
         Some(internal.into()),
     )
 }
 
 impl Error {
-    pub fn message(&self) -> String {
+    pub fn description(&self) -> String {
         match self {
-            Error::UserError(description, advice, None) => {
-                format!("Oh no! {}\nAdvice: {}", description, advice)
+            Error::UserError(description, ..) | Error::SystemError(description, ..) => {
+                description.clone()
             }
-            Error::UserError(description, advice, Some(internal)) => {
-                format!("Oh no! {}\nAdvice: {}\n\n{}", description, advice, internal)
+        }
+    }
+
+    pub fn message(&self) -> String {
+        let (description, internal) = match self {
+            Error::UserError(description, _, _, internal)
+            | Error::SystemError(description, _, _, internal) => (description, internal),
+        };
+
+        let hero_message = match self {
+            Error::UserError(_, _, _, _) => {
+                format!("Oh no! {}", description)
             }
-            Error::SystemError(description, advice, None) => format!(
-                "Whoops! {} (This isn't your fault)\nAdvice: {}",
-                description, advice
-            ),
-            Error::SystemError(description, advice, Some(internal)) => format!(
-                "Whoops! {} (This isn't your fault)\nAdvice: {}\n\n{}",
-                description, advice, internal
-            ),
+            Error::SystemError(_, _, _, _) => {
+                format!("Whoops! {} (This isn't your fault)", description)
+            }
+        };
+
+        match self.caused_by() {
+            Some(cause) => {
+                format!(
+                    "{}\n\nThis was caused by:\n{}\n\nTo try and fix this, you can:\n{}",
+                    hero_message,
+                    cause,
+                    self.advice()
+                )
+            }
+            None => {
+                format!(
+                    "{}\n\nTo try and fix this, you can:\n{}",
+                    hero_message,
+                    self.advice()
+                )
+            }
+        }
+    }
+
+    fn caused_by(&self) -> Option<String> {
+        match self {
+            Error::UserError(.., Some(cause), _) | Error::SystemError(.., Some(cause), _) => {
+                match cause.caused_by() {
+                    Some(child_cause) => {
+                        Some(format!(" - {}\n{}", cause.description(), child_cause))
+                    }
+                    None => Some(format!(" - {}", cause.description())),
+                }
+            }
+            Error::UserError(.., Some(internal)) | Error::SystemError(.., Some(internal)) => {
+                Some(format!(" - {}", internal))
+            }
+            _ => None,
+        }
+    }
+
+    fn advice(&self) -> String {
+        let (advice, cause) = match self {
+            Error::UserError(_, advice, cause, _) | Error::SystemError(_, advice, cause, _) => {
+                (advice, cause)
+            }
+        };
+
+        match cause {
+            // We bias towards the most specific advice first (i.e. the lowest-level error) because that's most likely to be correct.
+            Some(cause) => format!("{}\n - {}", cause.advice(), advice),
+            None => format!(" - {}", advice),
         }
     }
 
@@ -76,7 +160,7 @@ impl Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
-            Error::UserError(.., Some(ref err)) | Error::SystemError(_, _, Some(ref err)) => {
+            Error::UserError(.., Some(ref err)) | Error::SystemError(.., Some(ref err)) => {
                 err.source()
             }
             _ => None,

--- a/src/online/gitignore.rs
+++ b/src/online/gitignore.rs
@@ -253,7 +253,7 @@ bin/
                 panic!("It should return an error, not succeed");
             }
             Err(e) => {
-                assert_eq!(e.message(), "Oh no! We could not find one of the languages you requested.\nAdvice: Check that the languages you've provided are all available using the 'gt ignore' command.");
+                assert_eq!(e.message(), "Oh no! We could not find one of the languages you requested.\n\nTo try and fix this, you can:\n - Check that the languages you've provided are all available using the 'gt ignore' command.");
             }
         }
     }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -82,6 +82,7 @@ impl<C: Core> Task<C> for TestTask {
                 "Mock Error".to_string(),
                 "Configure the mock to not throw an error".to_string(),
                 None,
+                None,
             )),
             false => Ok(()),
         }
@@ -100,6 +101,7 @@ impl<C: Core> Task<C> for TestTask {
             true => Err(core::Error::SystemError(
                 "Mock Error".to_string(),
                 "Configure the mock to not throw an error".to_string(),
+                None,
                 None,
             )),
             false => Ok(()),


### PR DESCRIPTION
This PR changes the way in which we generate error messages to make it much clearer when a parent error is caused by a child, as well as combining the advice provided by each error in the hierarchy in a more logical manner.

The goal is to ensure that users can more easily understand the cause of a problem without us needing to rewrite every error message in the codebase.

In addition, we've made some small changes to the error messages returned by the resolver when you're in your dev directory, but not within a repository there.

### Before
> Oh no! Current directory ('G:\Programming\github.com\SierraSoftworks') is not a valid repository.
> Advice: Make sure that you are currently within a repository contained within your development directory ('\?\G:\Programming').
> 
> Oh no! The service 'github.com' requires a repository name in the form '\*/\*', but we got 'github.com\SierraSoftworks'.
> Advice: Make sure that your repository is correctly named for the service you are using.

### After
> Oh no! Current directory ('G:\Programming\github.com\SierraSoftworks') is not a valid repository.
> 
> This was caused by:
>  - The service 'github.com' requires a repository name in the form 'github.com/\*/\*', but you provided 'github.com\SierraSoftworks'.
> 
> To try and fix this, you can:
>  - Make sure that you are using a repository name which looks like 'github.com/\*/\*'.
>  - Make sure that you are currently within a repository contained within your development directory ('\\?\G:\Programming').