### PR TITLE
feat: Add the ability to opt out of Sentry error reporting and other telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,7 @@ dependencies = [
  "hyper-tls 0.5.0",
  "itertools 0.10.0",
  "keyring",
+ "lazy_static",
  "log",
  "nix",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ hyper = { version = "0.14", features = ["client","http1","http2"] }
 hyper-tls = "0.5"
 itertools = "0.10"
 keyring = "0.10"
+lazy_static = "1.4"
 log = "0.4"
 nix = "0.19.1"
 once_cell = "1.5"

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -1,6 +1,6 @@
 use super::super::errors;
 use super::*;
-use crate::tasks::*;
+use crate::{core::features, tasks::*};
 use clap::{App, Arg, ArgMatches};
 
 pub struct NewCommand {}
@@ -62,8 +62,7 @@ impl<C: Core> CommandRunnable<C> for NewCommand {
 
         tasks.apply_repo(core, &repo).await?;
 
-        if matches.is_present("open") || core.config().get_features().open_new_repo_in_default_app()
-        {
+        if matches.is_present("open") || core.config().get_features().has(features::OPEN_NEW_REPO) {
             let app = core.config().get_default_app().ok_or(errors::user(
                 "No default application available.",
                 "Make sure that you add an app to your config file using 'git-tool config add apps/bash' or similar."))?;

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -124,7 +124,7 @@ impl Config {
             dev_directory: dir.to_path_buf(),
             scratch_directory: None,
             features: features::Features::builder()
-                .with_use_http_transport(true)
+                .with(features::HTTP_TRANSPORT, true)
                 .build(),
             ..Default::default()
         }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -130,7 +130,6 @@ impl Config {
         }
     }
 
-    #[cfg(test)]
     pub fn from_str(yaml: &str) -> Result<Self, errors::Error> {
         serde_yaml::from_str(yaml)
             .map(|x| Config::default().extend(x))

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,7 +2,7 @@ mod app;
 mod auth;
 mod config;
 mod core;
-mod features;
+pub mod features;
 mod input;
 mod launcher;
 mod output;

--- a/src/core/prompt.rs
+++ b/src/core/prompt.rs
@@ -62,6 +62,16 @@ impl Prompter {
 
         Ok(None)
     }
+
+    pub fn prompt_bool(&mut self, message: &str) -> Result<Option<bool>, Error> {
+        if let Some(answer) = self.prompt(message, |l| {
+            l.to_lowercase() == "y" || l.to_lowercase() == "n"
+        })? {
+            Ok(Some(answer.to_lowercase() == "y"))
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -85,9 +85,8 @@ impl Error {
     }
 
     pub fn message(&self) -> String {
-        let (description, internal) = match self {
-            Error::UserError(description, _, _, internal)
-            | Error::SystemError(description, _, _, internal) => (description, internal),
+        let description = match self {
+            Error::UserError(description, ..) | Error::SystemError(description, ..) => description,
         };
 
         let hero_message = match self {

--- a/src/online/service/github.rs
+++ b/src/online/service/github.rs
@@ -30,7 +30,10 @@ impl<C: Core> OnlineService<C> for GitHubService {
 
         let new_repo = NewRepo {
             name: repo.get_name(),
-            private: core.config().get_features().create_remote_private(),
+            private: core
+                .config()
+                .get_features()
+                .has(features::CREATE_REMOTE_PRIVATE),
         };
 
         let req_body = serde_json::to_vec(&new_repo)?;

--- a/src/tasks/create_remote.rs
+++ b/src/tasks/create_remote.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::errors;
+use crate::{core::features, errors};
 
 pub struct CreateRemote {
     pub enabled: bool,
@@ -18,7 +18,7 @@ impl<C: Core> Task<C> for CreateRemote {
             return Ok(());
         }
 
-        if !core.config().get_features().create_remote() {
+        if !core.config().get_features().has(features::CREATE_REMOTE) {
             return Ok(());
         }
 

--- a/src/tasks/git_clone.rs
+++ b/src/tasks/git_clone.rs
@@ -1,3 +1,5 @@
+use crate::core::features;
+
 use super::*;
 use crate::{core::Target, errors, git};
 
@@ -16,7 +18,7 @@ impl<C: Core> Task<C> for GitClone {
                 &format!("Ensure that your git-tool configuration has a service entry for this service, or add it with `git-tool config add service/{}`", repo.get_domain()))
         )?;
 
-        let url = if core.config().get_features().use_http_transport() {
+        let url = if core.config().get_features().has(features::HTTP_TRANSPORT) {
             service.get_http_url(repo)?
         } else {
             service.get_git_url(repo)?

--- a/src/tasks/git_remote.rs
+++ b/src/tasks/git_remote.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::{core::Target, errors, git};
+use crate::{
+    core::{features, Target},
+    errors, git,
+};
 
 pub struct GitRemote<'a> {
     pub name: &'a str,
@@ -20,7 +23,7 @@ impl<'a, C: Core> Task<C> for GitRemote<'a> {
                 &format!("Ensure that your git-tool configuration has a service entry for this service, or add it with `git-tool config add service/{}`", repo.get_domain()))
         )?;
 
-        let url = if core.config().get_features().use_http_transport() {
+        let url = if core.config().get_features().has(features::HTTP_TRANSPORT) {
             service.get_http_url(repo)?
         } else {
             service.get_git_url(repo)?

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,0 +1,74 @@
+use std::sync::{Arc, RwLock};
+
+use sentry::ClientInitGuard;
+
+use crate::core::Error;
+
+lazy_static! {
+    static ref ENABLED: RwLock<bool> = RwLock::new(true);
+}
+
+pub fn is_enabled() -> bool {
+    ENABLED.read().map(|v| *v).unwrap_or_default()
+}
+
+pub fn set_enabled(enable: bool) {
+    ENABLED.write().map(|mut v| *v = enable).unwrap_or_default()
+}
+pub struct Session {
+    raven: ClientInitGuard,
+}
+
+impl Session {
+    pub fn new() -> Self {
+        let logger = sentry::integrations::log::SentryLogger::new();
+        log::set_boxed_logger(Box::new(logger)).unwrap();
+        log::set_max_level(log::LevelFilter::Debug);
+
+        let raven = sentry::init((
+            "https://0787127414b24323be5a3d34767cb9b8@o219072.ingest.sentry.io/1486938",
+            sentry::ClientOptions {
+                release: Some(version!("git-tool@v").into()),
+                default_integrations: true,
+                attach_stacktrace: true,
+                before_send: Some(Arc::new(|mut event| {
+                    if !is_enabled() {
+                        None
+                    } else {
+                        // Don't send the server name (as it may leak information about the user)
+                        event.server_name = None;
+
+                        Some(event)
+                    }
+                })),
+                ..Default::default()
+            },
+        ));
+
+        sentry::start_session();
+
+        Self { raven }
+    }
+
+    pub fn complete(&self) {
+        if !is_enabled() {
+            return;
+        }
+
+        sentry::end_session_with_status(sentry::protocol::SessionStatus::Exited);
+        self.raven.close(None);
+    }
+
+    pub fn crash(&self, err: Error) {
+        if !is_enabled() {
+            return;
+        }
+
+        if err.is_system() {
+            sentry::capture_error(&err);
+        }
+
+        sentry::end_session_with_status(sentry::protocol::SessionStatus::Crashed);
+        self.raven.close(None);
+    }
+}


### PR DESCRIPTION
This PR introduces a feature flag to control [Sentry](https://sentry.io) error reporting so that users can opt out of this behaviour if they wish.

Fixes #167