### PR TITLE
feat: Add the ability to control feature flags through the `gt config` CLI

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{Config, Error, Prompter},
+    core::{Error, Prompter},
     fs::to_native_path,
 };
 use std::{
@@ -83,14 +83,7 @@ impl<C: Core> CommandRunnable<C> for SetupCommand {
         let new_config = core
             .config()
             .with_dev_directory(&dev_directory)
-            .extend(Config::from_str(&format!(
-                "
-directory: '' # Empty directory will be ignored in extend
-features:
-    telemetry: {}
-",
-                if enable_telemetry { "true" } else { "false" }
-            ))?);
+            .with_feature_flag("telemetry", enable_telemetry);
 
         tokio::fs::write(&config_path, new_config.to_string()?).await.map_err(|err| errors::user_with_internal(
             &format!("We couldn't write the new config file to '{}' due to a system error.", config_path.display()),

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -37,6 +37,12 @@ impl Config {
         into
     }
 
+    pub fn with_feature_flag(&self, flag: &str, enabled: bool) -> Self {
+        let mut into = self.clone();
+        into.features = self.features.to_builder().with(flag, enabled).build();
+        into
+    }
+
     pub fn extend(&self, other: Self) -> Self {
         let mut into = self.clone();
         let from = other.clone();
@@ -130,6 +136,7 @@ impl Config {
         }
     }
 
+    #[cfg(test)]
     pub fn from_str(yaml: &str) -> Result<Self, errors::Error> {
         serde_yaml::from_str(yaml)
             .map(|x| Config::default().extend(x))

--- a/src/core/features.rs
+++ b/src/core/features.rs
@@ -10,24 +10,21 @@ pub const OPEN_NEW_REPO: &str = "open_new_repo_in_default_app";
 
 pub const TELEMETRY: &str = "telemetry";
 
+lazy_static! {
+    pub static ref ALL: Vec<&'static str> = vec![
+        HTTP_TRANSPORT,
+        CREATE_REMOTE,
+        CREATE_REMOTE_PRIVATE,
+        OPEN_NEW_REPO,
+        TELEMETRY
+    ];
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Features {
     #[serde(flatten)]
     flags: HashMap<String, bool>,
 }
-
-// {
-//     #[serde(default = "default_as_true")]
-//     native_clone: bool,
-//     #[serde(default = "default_as_true")]
-//     create_remote: bool,
-//     #[serde(default)]
-//     http_transport: bool,
-//     #[serde(default = "default_as_true")]
-//     create_remote_private: bool,
-//     #[serde(default)]
-//     open_new_repo_in_default_app: bool,
-// }
 
 impl Default for Features {
     fn default() -> Self {
@@ -45,6 +42,12 @@ impl Features {
 
     pub fn has(&self, flag: &str) -> bool {
         self.flags.get(flag).map(|&v| v).unwrap_or_default()
+    }
+
+    pub fn to_builder(&self) -> FeaturesBuilder {
+        FeaturesBuilder {
+            flags: self.flags.clone(),
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds the ability to configure feature flags through the `gt config feature` sub-command.

Fixes #87