### PR TITLE
fix: Correctly initialize the config file with the default features

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -130,6 +130,7 @@ impl Config {
             dev_directory: dir.to_path_buf(),
             scratch_directory: None,
             features: features::Features::builder()
+                .with_defaults()
                 .with(features::HTTP_TRANSPORT, true)
                 .build(),
             ..Default::default()
@@ -156,7 +157,7 @@ impl Config {
             err
         ))?;
 
-        let mut cfg = Config::from_reader(f)?;
+        let mut cfg = Config::default().extend(Config::from_reader(f)?);
         cfg.config_file = Some(path.to_path_buf());
 
         Ok(cfg)


### PR DESCRIPTION
This PR fixes an issue with the way that config files were loaded, which would result in the default feature configuration being ignored.