### PR TITLE
feat: Print out information about a feature flag's current state if no state is provided

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -186,7 +186,14 @@ impl CommandRunnable for ConfigCommand {
                         writeln!(output, "Cannot set the feature flag {} to {} because only 'true' and 'false' are valid settings.", flag, invalid)?;
                         return Ok(1);
                     }
-                    None => {}
+                    None => {
+                        writeln!(
+                            output,
+                            "{} = {}",
+                            flag,
+                            core.config().get_features().has(flag)
+                        )?;
+                    }
                 },
                 None => {
                     for &feature in features::ALL.iter() {


### PR DESCRIPTION
This PR adds the ability to view the state of a config feature flag by running `gt config feature telemetry` without providing a new enable/disable state. It will print out `telemetry = true` (or the appropriate flag and its value).