### PR TITLE
doc: Add information about the VC++ dependency on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ gt s
 
 Make sure you download the latest [release][] for your platform and place it in a directory on your `$PATH`.
 
+**NOTE** If you're on Windows, you may need to install the Microsoft Visual C++ Re-distributable package. You can find these
+on Microsoft's website [here](https://support.microsoft.com/en-ie/help/2977003/the-latest-supported-visual-c-downloads). If you
+are missing this, Git-Tool will not run from the command line and running the binary directly will display an error dialog.
+
 #### Step 2: Ensure that you can run `git-tool`
 
 ```

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -67,7 +67,10 @@ impl CommandRunnable for SetupCommand {
         )?;
 
         let enable_telemetry = prompter
-            .prompt_bool("Are you happy sharing crash reports with us automatically? [Y/n]: ")?
+            .prompt_bool(
+                "Are you happy sharing crash reports with us automatically? [Y/n]: ",
+                Some(true),
+            )?
             .unwrap_or(true);
 
         match config_path.parent() {

--- a/src/console/output.rs
+++ b/src/console/output.rs
@@ -29,6 +29,15 @@ pub mod mocks {
         written_data: Arc<Mutex<String>>,
     }
 
+    impl MockOutput {
+        pub fn clear(&self) {
+            self.written_data
+                .lock()
+                .map(|mut m| m.clear())
+                .unwrap_or_default();
+        }
+    }
+
     impl Default for MockOutput {
         fn default() -> Self {
             Self {

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use std::vec::Vec;
 use std::{collections::HashMap, path::Path};
+use std::{env::consts::OS, vec::Vec};
 use std::{path, sync::Arc};
 
 use super::super::errors;
@@ -268,12 +268,19 @@ impl Default for Config {
     fn default() -> Self {
         let dev_dir = path::PathBuf::from(std::env::var("DEV_DIRECTORY").unwrap_or_default());
 
+        let default_shell = match OS {
+            "linux" => "bash",
+            "macos" => "zsh",
+            "windows" => "powershell",
+            _ => "bash",
+        };
+
         Self {
             config_file: None,
             dev_directory: dev_dir,
             scratch_directory: None,
             apps: vec![
-                Arc::new(app::App::builder().with_name("shell").with_command("bash").into()),
+                Arc::new(app::App::builder().with_name("shell").with_command(default_shell).into()),
             ],
             services: vec![
                 Arc::new(service::Service::builder()

--- a/src/core/prompt.rs
+++ b/src/core/prompt.rs
@@ -56,13 +56,17 @@ impl Prompter {
         Ok(None)
     }
 
-    pub fn prompt_bool(&mut self, message: &str) -> Result<Option<bool>, Error> {
+    pub fn prompt_bool(
+        &mut self,
+        message: &str,
+        default: Option<bool>,
+    ) -> Result<Option<bool>, Error> {
         if let Some(answer) = self.prompt(message, |l| {
             l.to_lowercase() == "y" || l.to_lowercase() == "n"
         })? {
             Ok(Some(answer.to_lowercase() == "y"))
         } else {
-            Ok(None)
+            Ok(default)
         }
     }
 }
@@ -152,5 +156,29 @@ mod tests {
         );
 
         assert_eq!(output.to_string(), "First prompt: Second prompt: ");
+    }
+
+    #[test]
+    fn prompt_boolean() {
+        console::input::mock("y\nn\n\n\n");
+        let output = console::output::mock();
+
+        let mut prompter = Prompter::new();
+
+        assert_eq!(
+            prompter.prompt_bool("Works? [y/N]: ", Some(false)).unwrap(),
+            Some(true),
+        );
+        assert_eq!(output.to_string(), "Works? [y/N]: ");
+
+        assert_eq!(
+            prompter.prompt_bool("Works? [Y/n]: ", Some(true)).unwrap(),
+            Some(false),
+        );
+        assert_eq!(
+            prompter.prompt_bool("Works? [Y/n]: ", Some(true)).unwrap(),
+            Some(true),
+        );
+        assert_eq!(prompter.prompt_bool("Works? [Y/n]: ", None).unwrap(), None,);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             std::process::exit(status);
         }
         Result::Err(err) => {
-            error!("{}", err.message());
             println!("{}", err.message());
 
             session.crash(err);


### PR DESCRIPTION
This PR, amongst other things, addresses some issues with the first-run experience for new users, documents some Windows dependencies, stops us reporting some user-level errors (Sentry hooking `error!()` by default) etc.