### PR TITLE
fix: Don't report Git errors as system-level errors

### DIFF
--- a/src/console/output.rs
+++ b/src/console/output.rs
@@ -17,6 +17,7 @@ pub fn mock() -> mocks::MockOutput {
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 pub mod mocks {
     use super::*;
     use std::{

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -54,6 +54,7 @@ pub fn system(description: &str, advice: &str) -> Error {
     Error::SystemError(description.to_string(), advice.to_string(), None, None)
 }
 
+#[allow(dead_code)]
 pub fn system_with_cause(description: &str, advice: &str, cause: Error) -> Error {
     Error::SystemError(
         description.to_string(),

--- a/src/git/cmd.rs
+++ b/src/git/cmd.rs
@@ -18,7 +18,7 @@ pub async fn git_cmd(cmd: &mut Command) -> Result<String, errors::Error> {
 
     if !output.status.success() {
         match output.status.code() {
-            Some(code) => Err(errors::system_with_cause(
+            Some(code) => Err(errors::user_with_cause(
                 "Git exited with a failure status code.",
                 "Please check the output printed by Git to determine why the command failed and take appropriate action.",
                 errors::system(&format!("{:?} exited with status code {}.", cmd, code), &output_text))),

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -5,9 +5,11 @@ mod clone;
 mod cmd;
 mod commit;
 mod init;
-mod refs;
 mod remote;
 mod switch;
+
+#[cfg(test)]
+mod refs;
 
 pub use add::git_add;
 pub use branch::{git_branches, git_current_branch};
@@ -16,6 +18,8 @@ pub use clone::git_clone;
 pub use cmd::git_cmd;
 pub use commit::git_commit;
 pub use init::git_init;
-pub use refs::{git_rev_parse, git_update_ref};
 pub use remote::{git_remote_add, git_remote_list, git_remote_set_url};
 pub use switch::git_switch;
+
+#[cfg(test)]
+pub use refs::{git_rev_parse, git_update_ref};


### PR DESCRIPTION
Currently if a git command fails, Git-Tool will report it as a system error. This is almost always wrong, so let's report it as a user error for now and let people report issues themselves if they find any. 