### PR TITLE
fix: Move the helpful warning about missing a config file to the gt open command

### DIFF
--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -39,6 +39,11 @@ New applications can be configured either by making changes to your configuratio
 #[async_trait]
 impl CommandRunnable for OpenCommand {
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
+        if core.config().get_config_file().is_none() {
+            warn!("No configuration file has been loaded, continuing with defaults.");
+            writeln!(core.output(),"Hi! It looks like you haven't set up a Git-Tool config file yet. Try running `git-tool setup` to get started or make sure you've set the GITTOOL_CONFIG environment variable.\n")?;
+        }
+
         let (app, repo) = match helpers::get_launch_app(core, matches.value_of("app"), matches.value_of("repo")) {
             helpers::LaunchTarget::AppAndTarget(app, target) => {
                 (app, core.resolver().get_best_repo(target)?)

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,11 +117,6 @@ async fn run<'a>(
         }
     }
 
-    if core.config().get_config_file().is_none() {
-        warn!("No configuration file has been loaded, continuing with defaults.");
-        writeln!(core.output(),"Hi! It looks like you haven't set up a Git-Tool config file yet. Try running `git-tool setup` to get started or make sure you've set the GITTOOL_CONFIG environment variable.\n")?;
-    }
-
     for cmd in commands.iter() {
         if let Some(cmd_matches) = matches.subcommand_matches(cmd.name()) {
             sentry::add_breadcrumb(sentry::Breadcrumb {


### PR DESCRIPTION
Fixes #216