### PR TITLE
feat: Add support for updating to pre-release versions of Git-Tool

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -83,7 +83,7 @@ where {
         if matches.is_present("list") {
             for release in releases {
                 let style = if release.version == current_version {
-                    "*";
+                    "*"
                 } else if release.get_variant(&current_variant).is_none() {
                     "!"
                 } else {

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -24,6 +24,9 @@ impl Command for UpdateCommand {
             .arg(Arg::new("version")
                 .help("The version you wish to update to. Defaults to the latest available version.")
                 .index(1))
+            .arg(Arg::new("prerelease")
+                .help("Install pre-release and/or early access versions of Git-Tool.")
+                .long("prerelease"))
     }
 }
 
@@ -79,23 +82,32 @@ where {
 
         if matches.is_present("list") {
             for release in releases {
-                let mut style = " ";
-                if release.version == current_version {
-                    style = "*";
+                let style = if release.version == current_version {
+                    "*";
                 } else if release.get_variant(&current_variant).is_none() {
-                    style = "!"
-                }
+                    "!"
+                } else {
+                    " "
+                };
 
-                writeln!(output, "{} {}", style, release.id)?;
+                let suffix = if release.prerelease {
+                    " (pre-release)"
+                } else {
+                    ""
+                };
+
+                writeln!(output, "{} {}{}", style, release.id, suffix)?;
             }
 
             return Ok(0);
         }
 
-        let mut target_release =
-            Release::get_latest(releases.iter().filter(|&r| {
-                r.get_variant(&current_variant).is_some() && r.version > current_version
-            }));
+        let include_prerelease = matches.is_present("prerelease");
+        let mut target_release = Release::get_latest(releases.iter().filter(|&r| {
+            r.get_variant(&current_variant).is_some()
+                && r.version > current_version
+                && (!r.prerelease || include_prerelease)
+        }));
 
         if let Some(target_version) = matches.value_of("version") {
             target_release = releases.iter().find(|r| r.id == target_version);

--- a/src/update/github.rs
+++ b/src/update/github.rs
@@ -137,6 +137,7 @@ impl GitHubSource {
                     id: r.tag_name.clone(),
                     changelog: r.body.clone(),
                     version,
+                    prerelease: r.prerelease,
                     variants: self.get_variants_from_response(&r),
                 }),
                 Err(_) => {}

--- a/src/update/release.rs
+++ b/src/update/release.rs
@@ -6,6 +6,7 @@ pub struct Release {
     pub id: String,
     pub changelog: String,
     pub version: Version,
+    pub prerelease: bool,
     pub variants: Vec<ReleaseVariant>,
 }
 
@@ -96,24 +97,28 @@ mod tests {
                 id: "1".to_string(),
                 changelog: "".to_string(),
                 version: "1.1.7".parse().unwrap(),
+                prerelease: false,
                 variants: vec![],
             },
             Release {
                 id: "0".to_string(),
                 changelog: "".to_string(),
                 version: "1.0.0".parse().unwrap(),
+                prerelease: false,
                 variants: vec![],
             },
             Release {
                 id: "3".to_string(),
                 changelog: "".to_string(),
                 version: "2.3.1".parse().unwrap(),
+                prerelease: false,
                 variants: vec![],
             },
             Release {
                 id: "2".to_string(),
                 changelog: "".to_string(),
                 version: "2.1.0".parse().unwrap(),
+                prerelease: false,
                 variants: vec![],
             },
         ];
@@ -155,6 +160,7 @@ mod tests {
             id: "test".to_string(),
             changelog: "...".to_string(),
             version: "1.0.0".parse().unwrap(),
+            prerelease: false,
             variants: vec![
                 ReleaseVariant {
                     id: "windows-x64".to_string(),


### PR DESCRIPTION
This PR adds support for differentiating between pre-release and stable releases of Git-Tool when installing updates.