### PR TITLE
feat: Add a registry template for Mac OS finder

### DIFF
--- a/registry/apps/finder.yaml
+++ b/registry/apps/finder.yaml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
-name: Windows Explorer
-description: Launches Windows Explorer in the project directory.
+name: MacOS Finder
+description: Launches Finder in the directory of a repository or scratchpad.
 version: 1.0.0
 configs:
   - platform: windows
     app:
-      name: explorer
+      name: finder
       command: explorer
   - platform: darwin
     app:


### PR DESCRIPTION
This PR introduces a new `apps/finder` template which allows you to open the MacOS finder app in a repo using `gt o finder`.

To install it, you need to run `gt config add apps/finder`.