### PR TITLE
fix: Ensure that Azure DevOps paths are (by default) URL escaped to support spaces in repo names... 🤦

### DIFF
--- a/docs/config/templates.md
+++ b/docs/config/templates.md
@@ -72,3 +72,22 @@ construct:
     - **HttpURL**: https://github.com/SierraSoftworks/git-tool.git <Badge text="optional" type="warning" vertical="middle" />
 
 </FileTree>
+
+## Functions
+
+### `urlquery`
+The `urlquery` function allows you to encode a value in a format that is safe to
+include as part of a URL query or path component. It is particularly useful for
+services which support non-URI-safe characters in their repository names.
+
+A perfect example of this is Azure DevOps, which allows you to create repositories
+with spaces in their names (why GitHub and other services don't let you do this is
+a mystery to me 💣).
+
+To use the `urlquery` function, simply invoke it with the value you wish to encode
+when writing your template. For example, here's how you might us it to generate a
+valid URL for an Azure DevOps repository.
+
+```
+https://dev.azure.com/{{ .Repo.Namespace }}/_git/{{ .Repo.Name | urlquery }}
+```

--- a/registry/services/azure-devops.yaml
+++ b/registry/services/azure-devops.yaml
@@ -6,7 +6,7 @@ configs:
   - platform: any
     service:
       domain: dev.azure.com
-      website: "https://{{ .Service.Domain }}/{{ .Repo.Namespace }}/_git/{{ .Repo.Name }}"
-      httpUrl: "https://{{ .Service.Domain }}/{{ .Repo.Namespace }}/_git/{{ .Repo.Name }}"
-      gitUrl: "git@ssh.{{ .Service.Domain }}:v3/{{ .Repo.FullName }}"
+      website: "https://{{ .Service.Domain }}/{{ .Repo.Namespace | urlquery }}/_git/{{ .Repo.Name | urlquery }}"
+      httpUrl: "https://{{ .Service.Domain }}/{{ .Repo.Namespace | urlquery }}/_git/{{ .Repo.Name | urlquery }}"
+      gitUrl: "git@ssh.{{ .Service.Domain }}:v3/{{ .Repo.FullName | urlquery }}"
       pattern: "*/*/*"

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -319,9 +319,9 @@ impl Default for Config {
                 Arc::new(service::Service::builder()
                     .with_domain("dev.azure.com")
                     .with_pattern("*/*/*")
-                    .with_website("https://{{ .Service.Domain }}/{{ .Repo.Namespace }}/_git/{{ .Repo.Name }}")
-                    .with_git_url("git@ssh.{{ .Service.Domain }}:v3/{{ .Repo.FullName }}")
-                    .with_http_url("https://{{ .Service.Domain }}/{{ .Repo.Namespace }}/_git/{{ .Repo.Name }}")
+                    .with_website("https://{{ .Service.Domain }}/{{ .Repo.Namespace | urlquery }}/_git/{{ .Repo.Name | urlquery }}")
+                    .with_git_url("git@ssh.{{ .Service.Domain }}:v3/{{ .Repo.FullName | urlquery }}")
+                    .with_http_url("https://{{ .Service.Domain }}/{{ .Repo.Namespace | urlquery }}/_git/{{ .Repo.Name | urlquery }}")
                     .into()),
             ],
             aliases: HashMap::new(),

--- a/src/core/service.rs
+++ b/src/core/service.rs
@@ -158,4 +158,34 @@ mod tests {
             "https://github.com/sierrasoftworks/git-tool"
         );
     }
+
+    #[test]
+    fn service_uri_encoding() {
+        let svc: Service = Service::builder()
+            .with_domain("dev.azure.com")
+            .with_pattern("*/*/*")
+            .with_website(
+                "https://dev.azure.com/{{ .Repo.Namespace }}/_git/{{ .Repo.Name | urlquery }}",
+            )
+            .with_git_url("git@ssh.dev.azure.com:v3/{{ .Repo.FullName | urlquery }}.git")
+            .with_http_url(
+                "https://dev.azure.com/{{ .Repo.Namespace }}/_git/{{ .Repo.Name | urlquery }}",
+            )
+            .into();
+
+        let repo = Repo::new(
+            "dev.azure.com/sierrasoftworks/example/git tool",
+            PathBuf::from("/test"),
+        );
+
+        assert_eq!(
+            svc.get_http_url(&repo).unwrap(),
+            "https://dev.azure.com/sierrasoftworks/example/_git/git%20tool"
+        );
+
+        assert_eq!(
+            svc.get_git_url(&repo).unwrap(),
+            "git@ssh.dev.azure.com:v3/sierrasoftworks/example/git%20tool.git"
+        );
+    }
 }


### PR DESCRIPTION
This PR makes some changes to the default configuration, as well as the published Azure DevOps service in the registry, to ensure that repo names and namespaces are URL encoded (i.e. replace ` ` with `%20`) so that we can support repositories that have spaces in their names without needing to jump through ridiculous hoops.

##### Before
```bash
> gt o "dev.azure.com/sierrasoftworks/example/test repo"

💣 💩

> gt o dev.azure.com/sierrasoftworks/example/test%20repo

✅ 🤮
```

#### After
##### Before
```bash
> gt o "dev.azure.com/sierrasoftworks/example/test repo"

🌈
```