### PR TITLE
feat: Add a new `gt prune` command to remove local branches that have been merged already

### DIFF
--- a/docs/commands/dev.md
+++ b/docs/commands/dev.md
@@ -76,7 +76,7 @@ can be a bit of a chore, so Git-Tool provides a `prune` command which will ident
 any merged branches (using `git branch --merged`) and remove them for you automatically.
 
 #### Options
- - `--yes/-y` will skip the confirmation prompt and remove any branches that are found.
+ - `-y`, `--yes` will skip the confirmation prompt and remove any branches that are found.
 
 #### Example
 ``` powershell

--- a/docs/commands/dev.md
+++ b/docs/commands/dev.md
@@ -66,3 +66,20 @@ Git-Tool will automatically fetch the latest ignore files from [gitignore.io](ht
 for the languages you have added whenever you run `gt ignore $LANG` and retain changes you made outside
 the metadata blocks.
 :::
+
+
+## prune <Badge text="v2.3.0+"/>
+If you're the kind of person who uses branches and Pull Requests to make changes
+to your repositories, you'll often end up with a small horde of branches in your
+local repository which are remnants of previously merged PRs. Cleaning these out
+can be a bit of a chore, so Git-Tool provides a `prune` command which will identify
+any merged branches (using `git branch --merged`) and remove them for you automatically.
+
+#### Options
+ - `--yes/-y` will skip the confirmation prompt and remove any branches that are found.
+
+#### Example
+``` powershell
+# Remove any merged branches from your local repository
+gt prune
+```

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -24,6 +24,7 @@ mod info;
 mod list;
 mod new;
 mod open;
+mod prune;
 mod remove;
 mod scratch;
 mod services;
@@ -62,6 +63,7 @@ pub fn commands() -> Vec<Arc<dyn CommandRunnable>> {
         Arc::new(list::ListCommand {}),
         Arc::new(new::NewCommand {}),
         Arc::new(open::OpenCommand {}),
+        Arc::new(prune::PruneCommand {}),
         Arc::new(remove::RemoveCommand {}),
         Arc::new(scratch::ScratchCommand {}),
         Arc::new(services::ServicesCommand {}),

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -111,6 +111,7 @@ mod tests {
 
     use super::*;
     use crate::core::*;
+    use crate::tasks::{self, Task};
     use complete::helpers::test_completions_with_core;
     use mocktopus::mocking::*;
     use tempfile::tempdir;

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -1,0 +1,337 @@
+use super::super::errors;
+use super::*;
+use crate::core::Target;
+use crate::git;
+use clap::{App, Arg};
+use itertools::Itertools;
+
+pub struct PruneCommand {}
+
+impl Command for PruneCommand {
+    fn name(&self) -> String {
+        String::from("prune")
+    }
+
+    fn app<'a>(&self) -> App<'a> {
+        App::new(self.name().as_str())
+            .version("1.0")
+            .about("removes local branches that have been merged.")
+            .long_about(
+                "This command identifies branches in your local repository which have been merged
+                into upstream branches and will proceed to delete them. This is particularly helpful
+                if you use feature branches as part of your workflow and want to get rid of old ones.",
+            )
+            .arg(
+                Arg::new("yes")
+                    .long("yes")
+                    .short('y')
+                    .help("Do not prompt for confirmation before deleting branches"),
+            )
+            .arg(Arg::new("pattern")
+                .help("The branch patterns which should be pruned")
+                .takes_value(true)
+                .multiple_values(true))
+    }
+}
+
+#[async_trait]
+impl CommandRunnable for PruneCommand {
+    async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
+        let repo = core.resolver().get_current_repo()?;
+
+        let default_branch = match git::git_default_branch(&repo.get_path()).await {
+            Ok(default_branch) => default_branch,
+            Err(e) => return Err(errors::user_with_cause(
+                "Could not determine the default branch for your repository, this probably means that you do not have a synchronized `origin`.", 
+                "Make sure that you have a correctly configured `origin` and that you have run `git fetch` before running this command again.",
+                e)),
+        };
+
+        let merged = match git::git_merged_branches(&repo.get_path()).await {
+            Ok(merged) => merged,
+            Err(e) => return Err(errors::user_with_cause(
+                "Could not determine the branches that have been merged into the default branch.",
+                "Make sure that you have a correctly configured `origin` and that you have run `git fetch` before running this command again.",
+                e)),
+        };
+
+        let to_remove: Vec<&String> = merged
+            .iter()
+            .filter(|&b| b != &default_branch)
+            .unique()
+            .collect();
+
+        if to_remove.is_empty() {
+            writeln!(core.output(), "No branches to remove")?;
+            return Ok(0);
+        }
+
+        if !matches.is_present("yes") {
+            writeln!(core.output(), "The following branches will be removed:")?;
+            for branch in to_remove.iter() {
+                writeln!(core.output(), "  {}", branch)?;
+            }
+            writeln!(core.output(), "")?;
+            writeln!(
+                core.output(),
+                "Are you sure you want to remove these branches?"
+            )?;
+            writeln!(core.output(), "Type 'yes' to continue:")?;
+
+            let input = crate::console::prompt::prompt(
+                "Are you sure you want to remove these branches? [y/N]: ",
+                "n",
+            );
+
+            if input.to_lowercase().trim() != "y" {
+                writeln!(core.output(), "Okay, we'll keep them as-is.")?;
+                return Ok(0);
+            }
+        }
+
+        for branch in to_remove.iter() {
+            git::git_branch_delete(&repo.get_path(), branch).await?;
+        }
+
+        Ok(0)
+    }
+
+    async fn complete(&self, core: &Core, completer: &Completer, _matches: &ArgMatches) {
+        if let Ok(repo) = core.resolver().get_current_repo() {
+            completer.offer("--yes");
+            if let Ok(branches) = git::git_merged_branches(&repo.get_path()).await {
+                completer.offer_many(branches.iter().unique().sorted());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::core::*;
+    use complete::helpers::test_completions_with_core;
+    use mocktopus::mocking::*;
+    use tempfile::tempdir;
+
+    /// Sets up a test repo in your provided temp directory.
+    ///
+    /// Creates a pair of repos in your provided temp directory,
+    /// initializing the first with a `feature/test` branch and `main` branch.
+    /// The second is cloned from the first and the `main` branch is then updated
+    /// with a new commit.
+    /// The second repo is then returned to the caller and configured to be the
+    /// mock result for the current repo.
+    ///
+    /// ## Branches
+    ///  - `origin/feature/test`
+    ///  - `origin/main`
+    ///  - `main`
+    ///  ` `feature/test2`
+    async fn setup_test_repo_with_remote(core: &Core, temp: &tempfile::TempDir) -> Repo {
+        let repo: Repo = core::Repo::new(
+            "github.com/sierrasoftworks/test-git-switch-command",
+            temp.path().join("repo").into(),
+        );
+
+        let repo_path = repo.get_path();
+        Resolver::get_current_repo.mock_safe(move |_| {
+            MockResult::Return(Ok(core::Repo::new(
+                "github.com/sierrasoftworks/test-git-switch-command",
+                repo_path.clone(),
+            )))
+        });
+
+        let origin_repo = core::Repo::new(
+            "github.com/sierrasoftworks/test-git-switch-command2",
+            temp.path().join("repo2").into(),
+        );
+
+        sequence!(
+            // Run a `git init` to setup the repo
+            tasks::GitInit {},
+            tasks::GitRemote { name: "origin" },
+            // Create the branch we want to switch to
+            tasks::GitCheckout {
+                branch: "feature/test".into(),
+            },
+            tasks::WriteFile {
+                path: "README.md".into(),
+                content: "This is an example README file.",
+            },
+            tasks::GitAdd {
+                paths: vec!["README.md"],
+            },
+            tasks::GitCommit {
+                message: "Add README.md",
+                paths: vec!["README.md"],
+            },
+            tasks::GitCheckout {
+                branch: "main".into(),
+            }
+        )
+        .apply_repo(core, &origin_repo)
+        .await
+        .unwrap();
+
+        sequence!(tasks::GitInit {}, tasks::GitRemote { name: "origin" })
+            .apply_repo(core, &repo)
+            .await
+            .unwrap();
+
+        git::git_remote_set_url(
+            &repo.get_path(),
+            "origin",
+            origin_repo.get_path().to_str().unwrap(),
+        )
+        .await
+        .unwrap();
+
+        git::git_fetch(&repo.get_path(), "origin").await.unwrap();
+
+        sequence!(
+            tasks::GitSwitch {
+                branch: "main".into(),
+                create_if_missing: false,
+            },
+            tasks::GitSwitch {
+                branch: "feature/test2".into(),
+                create_if_missing: true,
+            },
+            tasks::WriteFile {
+                path: "README.md".into(),
+                content: "This is an example README file with some changes.",
+            },
+            tasks::GitAdd {
+                paths: vec!["README.md"],
+            },
+            tasks::GitCommit {
+                message: "Update README.md",
+                paths: vec!["README.md"],
+            },
+            tasks::GitSwitch {
+                branch: "main".into(),
+                create_if_missing: false,
+            },
+            tasks::WriteFile {
+                path: ".git/refs/remotes/origin/HEAD".into(),
+                content: "ref: refs/remotes/origin/main".into(),
+            }
+        )
+        .apply_repo(core, &repo)
+        .await
+        .unwrap();
+
+        assert!(repo.valid(), "the repository should exist and be valid");
+        repo
+    }
+
+    #[tokio::test]
+    async fn prune_completions() {
+        let temp = tempdir().unwrap();
+
+        let core = core::Core::builder()
+            .with_config(&core::Config::for_dev_directory(temp.path()))
+            .build();
+
+        let repo: Repo = setup_test_repo_with_remote(&core, &temp).await;
+
+        crate::git::git_cmd(
+            tokio::process::Command::new("git")
+                .current_dir(&repo.get_path())
+                .arg("merge")
+                .arg("feature/test2"),
+        )
+        .await
+        .unwrap();
+
+        Resolver::get_current_repo.mock_safe(move |_| MockResult::Return(Ok(repo.clone())));
+
+        test_completions_with_core(&core, "gt prune", "", vec!["--yes", "feature/test2"]).await;
+    }
+
+    #[tokio::test]
+    async fn prune_local_only_branch() {
+        let cmd: PruneCommand = PruneCommand {};
+
+        let temp = tempdir().unwrap();
+
+        let core = core::Core::builder()
+            .with_config(&core::Config::for_dev_directory(temp.path()))
+            .build();
+
+        crate::console::prompt::mock(Some("y"));
+
+        let repo: Repo = setup_test_repo_with_remote(&core, &temp).await;
+
+        {
+            let repo = repo.clone();
+            Resolver::get_current_repo.mock_safe(move |_| MockResult::Return(Ok(repo.clone())));
+        }
+
+        crate::git::git_cmd(
+            tokio::process::Command::new("git")
+                .current_dir(&repo.get_path())
+                .arg("merge")
+                .arg("feature/test2"),
+        )
+        .await
+        .unwrap();
+
+        let mut branches = git::git_branches(&repo.get_path()).await.unwrap();
+        branches.sort();
+        assert_eq!(branches, vec!["feature/test", "feature/test2", "main"]);
+
+        assert_eq!(
+            git::git_merged_branches(&repo.get_path()).await.unwrap(),
+            vec!["feature/test2"]
+        );
+
+        let args: ArgMatches = cmd.app().get_matches_from(vec!["prune"]);
+        cmd.run(&core, &args).await.unwrap();
+
+        assert!(repo.valid(), "the repository should still be valid");
+        let mut branches = git::git_branches(&repo.get_path()).await.unwrap();
+        branches.sort();
+        assert_eq!(branches, vec!["feature/test", "main"]);
+    }
+
+    #[tokio::test]
+    async fn prune_bare_repo() {
+        let cmd: PruneCommand = PruneCommand {};
+
+        let temp = tempdir().unwrap();
+        let repo: Repo = core::Repo::new(
+            "github.com/sierrasoftworks/test-git-prune-command",
+            temp.path().join("repo").into(),
+        );
+
+        let core = core::Core::builder()
+            .with_config(&core::Config::for_dev_directory(&temp.path()))
+            .build();
+
+        Resolver::get_current_repo.mock_safe(move |_| {
+            MockResult::Return(Ok(core::Repo::new(
+                "github.com/sierrasoftworks/test-git-prune-command",
+                temp.path().join("repo").into(),
+            )))
+        });
+
+        // Run a `git init` to setup the repo
+        tasks::GitInit {}.apply_repo(&core, &repo).await.unwrap();
+
+        assert!(repo.valid(), "the repository should exist and be valid");
+
+        let args: ArgMatches = cmd.app().get_matches_from(vec!["prune"]);
+        cmd.run(&core, &args)
+            .await
+            .expect_err("the command should fail");
+
+        assert!(repo.valid(), "the repository should still be valid");
+        assert!(git::git_branches(&repo.get_path())
+            .await
+            .unwrap()
+            .is_empty());
+    }
+}

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -1,2 +1,3 @@
 pub mod input;
 pub mod output;
+pub mod prompt;

--- a/src/console/prompt.rs
+++ b/src/console/prompt.rs
@@ -1,0 +1,30 @@
+#[cfg(test)]
+use mocktopus::{macros::*, mocking::*};
+
+#[cfg_attr(test, mockable)]
+pub fn prompt(msg: &str, default: &str) -> String {
+    match write!(super::output::output(), "{}", msg) {
+        Ok(_) => (),
+        Err(_) => {
+            return default.into();
+        }
+    };
+
+    let mut input = String::new();
+    match std::io::stdin().read_line(&mut input) {
+        Ok(_) => (),
+        Err(_) => {
+            return default.into();
+        }
+    };
+
+    input.trim().to_string()
+}
+
+#[cfg(test)]
+pub fn mock(answer: Option<&str>) {
+    let answer = answer.map(|s| s.to_string());
+    prompt.mock_safe(move |_prompt, default| {
+        MockResult::Return(answer.clone().unwrap_or(default.into()))
+    });
+}

--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -1,5 +1,6 @@
 use super::git_cmd;
 use crate::errors;
+use itertools::intersperse;
 use std::{collections::HashSet, path};
 use tokio::process::Command;
 
@@ -34,8 +35,8 @@ pub async fn git_branches(repo: &path::Path) -> Result<Vec<String>, errors::Erro
 
     let mut unique_refs = HashSet::new();
     for r in refs {
-        if r.starts_with("remotes/") {
-            match r.splitn(3, '/').nth(2) {
+        if r.starts_with("origin/") {
+            match r.splitn(2, '/').nth(1) {
                 Some(rs) => unique_refs.insert(rs),
                 None => unique_refs.insert(r),
             };
@@ -45,6 +46,24 @@ pub async fn git_branches(repo: &path::Path) -> Result<Vec<String>, errors::Erro
     }
 
     Ok(unique_refs.iter().map(|s| s.to_string()).collect())
+}
+
+pub async fn git_default_branch(repo: &path::Path) -> Result<String, errors::Error> {
+    info!("Running `git symbolic-ref refs/remotes/origin/HEAD` to get the default branch");
+    Ok(intersperse(
+        git_cmd(
+            Command::new("git")
+                .current_dir(repo)
+                .arg("symbolic-ref")
+                .arg("refs/remotes/origin/HEAD"),
+        )
+        .await?
+        .trim()
+        .split('/')
+        .skip(3),
+        "/",
+    )
+    .collect())
 }
 
 #[cfg(test)]
@@ -126,20 +145,12 @@ mod tests {
         git_update_ref(&repo.get_path(), "refs/heads/test", &current_sha)
             .await
             .unwrap();
-        git_update_ref(
-            &repo.get_path(),
-            "refs/heads/remotes/origin/main",
-            &current_sha,
-        )
-        .await
-        .unwrap();
-        git_update_ref(
-            &repo.get_path(),
-            "refs/heads/remotes/origin/test2",
-            &current_sha,
-        )
-        .await
-        .unwrap();
+        git_update_ref(&repo.get_path(), "refs/remotes/origin/main", &current_sha)
+            .await
+            .unwrap();
+        git_update_ref(&repo.get_path(), "refs/remotes/origin/test2", &current_sha)
+            .await
+            .unwrap();
 
         let branch = git_branches(&repo.get_path())
             .await
@@ -157,7 +168,69 @@ mod tests {
         );
         assert!(
             branch.iter().any(|x| x == "test2"),
-            "'test' should be present in the list"
+            "'test2' should be present in the list"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_default_branch() {
+        let temp = tempdir().unwrap();
+        let repo = Repo::new("github.com/sierrasoftworks/test1", temp.path().into());
+        let core = Core::builder()
+            .with_config(&Config::for_dev_directory(temp.path()))
+            .build();
+
+        sequence![
+            GitInit {},
+            GitRemote { name: "origin" },
+            GitCheckout { branch: "main" },
+            WriteFile {
+                path: PathBuf::from("README.md"),
+                content: "This is a test file".into(),
+            },
+            GitAdd {
+                paths: vec!["README.md"]
+            },
+            GitCommit {
+                message: "Test",
+                paths: vec!["README.md"],
+            }
+        ]
+        .apply_repo(&core, &repo)
+        .await
+        .expect("the repo should have been prepared properly");
+
+        let current_sha = git_rev_parse(&repo.get_path(), "HEAD")
+            .await
+            .expect("to get the current HEAD SHA");
+
+        assert_ne!(current_sha, "", "the current SHA shouldn't be empty");
+
+        git_update_ref(&repo.get_path(), "refs/remotes/origin/main", &current_sha)
+            .await
+            .unwrap();
+
+        git_update_ref(&repo.get_path(), "refs/heads/origin/test2", &current_sha)
+            .await
+            .unwrap();
+
+        WriteFile {
+            path: PathBuf::from(".git/refs/remotes/origin/HEAD"),
+            content: "ref: refs/remotes/origin/main".into(),
+        }
+        .apply_repo(&core, &repo)
+        .await
+        .unwrap();
+
+        let default_branch = git_default_branch(&repo.get_path())
+            .await
+            .expect("should be able to get the branches list");
+
+        println!("{:?}", default_branch);
+
+        assert_eq!(
+            default_branch, "main",
+            "'main' should be present in the list"
         );
     }
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -13,7 +13,9 @@ mod switch;
 mod refs;
 
 pub use add::git_add;
-pub use branch::{git_branches, git_current_branch};
+pub use branch::{
+    git_branch_delete, git_branches, git_current_branch, git_default_branch, git_merged_branches,
+};
 pub use checkout::git_checkout;
 pub use clone::git_clone;
 pub use cmd::git_cmd;

--- a/src/tasks/write_file.rs
+++ b/src/tasks/write_file.rs
@@ -13,6 +13,11 @@ impl<'a> Task for WriteFile<'a> {
     async fn apply_repo(&self, _core: &Core, repo: &core::Repo) -> Result<(), core::Error> {
         let path = repo.get_path().join(&self.path);
 
+        match path.parent() {
+            Some(parent) => tokio::fs::create_dir_all(parent).await?,
+            None => {}
+        };
+
         tokio::fs::write(&path, self.content).await.map_err(|err| {
             errors::user_with_internal(
                 &format!(


### PR DESCRIPTION
This PR introduces a new `gt prune` command which allows you to quickly remove any local branch refs which have been merged. This is particularly useful if you use unique branches for PRs and want to clean out the cruft once your PRs are merged.