### PR TITLE
feat: Add OpenTelemetry tracing to assist with debugging errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,10 +34,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.53"
+name = "aho-corasick"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "async-io"
@@ -56,6 +74,27 @@ dependencies = [
  "socket2",
  "waker-fn",
  "winapi",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -82,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -149,9 +188,9 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -214,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -230,11 +269,31 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+dependencies = [
+ "cfg-if 1.0.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -249,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "debugid"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91cf5a8c2f2097e2a32627123508635d47ce10563d999ec1a95addf08b502ba"
+checksum = "d6ee87af31d84ef885378aebca32be3d682b0e0dc119d5b4860a2c5bb5046730"
 dependencies = [
  "serde",
  "uuid",
@@ -306,9 +365,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -342,6 +401,12 @@ checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "fnv"
@@ -475,13 +540,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -500,12 +565,14 @@ dependencies = [
  "itertools",
  "keyring",
  "lazy_static",
- "log",
  "mocktopus",
  "nix 0.23.1",
  "once_cell",
+ "opentelemetry",
+ "opentelemetry-otlp",
  "reqwest",
  "rpassword",
+ "rustls 0.19.1",
  "semver",
  "sentry",
  "serde",
@@ -514,6 +581,11 @@ dependencies = [
  "shell-words",
  "tempfile",
  "tokio",
+ "tonic",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+ "webpki-roots 0.21.1",
 ]
 
 [[package]]
@@ -541,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
  "bytes",
  "fnv",
@@ -554,7 +626,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.1",
  "tracing",
 ]
 
@@ -563,6 +635,15 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -607,7 +688,7 @@ checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.1",
+ "itoa",
 ]
 
 [[package]]
@@ -623,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "6330e8a36bd8c859f3fa6d9382911fbb7147ec39807f63b923933a247240b9ba"
 
 [[package]]
 name = "httpdate"
@@ -641,9 +722,9 @@ checksum = "c1a2d5ae7ab61b4b658b6c88d10851ec539087a775083df8ce30e6598241328f"
 
 [[package]]
 name = "hyper"
-version = "0.14.16"
+version = "0.14.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
+checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -654,7 +735,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 0.4.8",
+ "itoa",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -671,9 +752,21 @@ checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
  "http",
  "hyper",
- "rustls",
+ "rustls 0.20.4",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.3",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -689,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -708,9 +801,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
 
 [[package]]
 name = "itertools"
@@ -723,21 +816,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.56"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
+checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -762,15 +849,25 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.113"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
 
 [[package]]
 name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
+name = "lock_api"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -810,14 +907,15 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
  "log",
  "miow",
  "ntapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -849,6 +947,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nb-connect"
@@ -888,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
 ]
@@ -983,9 +1087,9 @@ dependencies = [
 
 [[package]]
 name = "num_threads"
-version = "0.1.2"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a1eb3a36534514077c1e079ada2fb170ef30c47d203aa6916138cf882ecd52"
+checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
 dependencies = [
  "libc",
 ]
@@ -1003,6 +1107,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "opentelemetry"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project",
+ "rand",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1a6ca9de4c8b00aa7f1a153bd76cb263287155cec642680d79d98706f3d28a"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-util",
+ "http",
+ "opentelemetry",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,10 +1161,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1065,9 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
  "thiserror",
  "toml",
@@ -1075,32 +1271,84 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.15"
+name = "prost"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+dependencies = [
+ "bytes",
+ "prost",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
 ]
 
 [[package]]
@@ -1123,32 +1371,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
  "redox_syscall",
+ "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -1182,19 +1439,19 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.4",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
- "tokio-util",
+ "tokio-rustls 0.23.3",
+ "tokio-util 0.6.9",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.22.3",
  "winreg",
 ]
 
@@ -1227,14 +1484,27 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.2"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
 dependencies = [
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.7.0",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -1257,6 +1527,22 @@ name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sct"
@@ -1365,7 +1651,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.6",
+ "time 0.3.9",
  "url",
  "uuid",
 ]
@@ -1396,7 +1682,7 @@ version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
- "itoa 1.0.1",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -1419,7 +1705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.1",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -1450,6 +1736,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,15 +1761,21 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+
+[[package]]
+name = "smallvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "socket2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f82496b90c36d70af5fcd482edaa2e0bd16fade569de1330405fecbbdac736b"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
@@ -1506,9 +1807,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1531,9 +1832,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -1565,6 +1866,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1576,11 +1886,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d54b9298e05179c335de2b9645d061255bcd5155f843b3e328d2cfe0a5b413"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
- "itoa 1.0.1",
+ "itoa",
  "libc",
  "num_threads",
 ]
@@ -1602,9 +1912,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
  "bytes",
  "libc",
@@ -1612,10 +1922,22 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1631,13 +1953,35 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
- "rustls",
+ "rustls 0.19.1",
  "tokio",
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4151fda0cf2798550ad0b34bcfc9b9dcc2a9d2471c895c68f3a8818e54f2389e"
+dependencies = [
+ "rustls 0.20.4",
+ "tokio",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1655,6 +1999,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1664,6 +2022,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-rustls 0.22.0",
+ "tokio-stream",
+ "tokio-util 0.6.9",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
+dependencies = [
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util 0.7.1",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+
+[[package]]
 name = "tower-service"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,22 +2099,84 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "80b9fa4360528139bc96100c160b7ae879f5567f49f1782b0b02035b0358ebf3"
 dependencies = [
  "cfg-if 1.0.0",
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.1.21"
+name = "tracing-attributes"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dfce9f3241b150f36e8e54bb561a742d5daa1a47b5dd9a5ce369fd4a4db2210"
 dependencies = [
  "lazy_static",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f9378e96a9361190ae297e7f3a8ff644aacd2897f244b1ff81f381669196fa6"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
+dependencies = [
+ "ansi_term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1715,6 +2205,12 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-xid"
@@ -1752,6 +2248,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,10 +2288,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.79"
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -1797,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
+checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1812,9 +2320,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
+checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1824,9 +2332,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
+checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1834,9 +2342,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
+checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1847,18 +2355,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "web-sys"
-version = "0.3.56"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
+checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1873,11 +2391,20 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.2"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
+dependencies = [
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -1887,6 +2414,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "which"
+version = "4.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]
@@ -1919,6 +2457,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "winreg"
@@ -1993,7 +2574,7 @@ version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4ca5e22593eb4212382d60d26350065bf2a02c34b85bc850474a74b589a3de9"
 dependencies = [
- "proc-macro-crate 1.1.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,13 @@ http = "0.2"
 itertools = "0.10"
 keyring = { version = "1.1", optional = true }
 lazy_static = "1.4"
-log = "0.4"
 nix = "0.23.1"
+opentelemetry = { version = "0.17", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.10", features = ["tls"] }
 once_cell = "1.10"
 rpassword = { version = "6.0", optional = true }
 reqwest = { version = "0.11.10", default-features = false, features = ["rustls-tls", "json", "stream"] }
+rustls = "0.19"
 semver = "1.0"
 sentry = { version = "0.25", default-features = false, features = ["reqwest", "log", "rustls"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
@@ -34,6 +36,11 @@ serde_json = "1.0"
 serde_yaml = "0.8"
 shell-words = "1.1"
 tokio = { version = "1.16", features = ["rt", "time", "fs", "process", "macros", "signal"] }
+tonic = { version = "0.6.2", features = ["tls"] }
+tracing = "0.1"
+tracing-opentelemetry = "0.17"
+tracing-subscriber = { version = "0.3", features = ["tracing-log"] }
+webpki-roots = "0.21.1"
 
 [dev-dependencies]
 mocktopus = "0.7.11"

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -93,6 +93,7 @@ export default defineUserConfig<DefaultThemeOptions>({
             '/guide/github.md',
             '/guide/updates.md',
             '/guide/migrating-v3.md',
+            '/guide/reporting-errors.md',
             '/guide/faq.md'
           ]
         }

--- a/docs/commands/overview.md
+++ b/docs/commands/overview.md
@@ -38,3 +38,7 @@ Git-Tool has a wealth of configuration options available and discovering them al
 
 [Read more about tweaking your config →](config.md)
 
+## Global Flags
+- `--help` will print contextual help for the command you're about to run, it's always up to date and great for figuring out how to use Git-Tool.
+- `-c`/`--config` allows you to specify the path to the configuration file you want to use with Git-Tool. By default this will use your `GITTOOL_CONFIG` environment variable's value, or `~/.git-tool.yml` if that isn't set.
+- `--trace` <Badge text="v3.1+" /> will generate a Trace ID for you and print it to console, it's great if you're trying to help us troubleshoot a problem.

--- a/docs/guide/reporting-errors.md
+++ b/docs/guide/reporting-errors.md
@@ -1,0 +1,25 @@
+---
+description: How to report a problem with Git-Tool to maximize the chances of getting it fixed.
+---
+
+# Reporting Errors
+Git-Tool is designed to be as robust and safe as possible, however all software
+will fail at some point or other. While we try to make understanding failures as
+easy as possible, and suggest how you might be able to fix a problem when it does
+occur, there will probably be times when you need to raise an issue for help.
+
+We use [GitHub](https://github.com/SierraSoftworks/git-tool/issues/new/choose) to
+track issues and will be happy to help with any problems you're facing. That said,
+there are a few things you can do to help us do a better job of helping you.
+
+1. Use our [Bug Report](https://github.com/SierraSoftworks/git-tool/issues/new/choose) template on GitHub.
+2. Tell us which version of Git-Tool you are using (and try the latest version to see if it solves your problem).
+3. If you can reproduce the issue, please run Git-Tool with the `--trace` argument and attach the Trace ID to the issue.
+4. Please provide as much context as you can about what you were doing when the error occurred.
+
+::: tip
+If you have telemetry reporting enabled, a Trace ID will automatically be generated for you whenever
+an error occurs, saving you the hassle of needing to reproduce the problem with `--trace`.
+
+You can enable telemetry by running `gt config feature telemetry true`.
+:::

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -16,6 +16,7 @@ impl Command for AppsCommand {
 
 #[async_trait]
 impl CommandRunnable for AppsCommand {
+    #[tracing::instrument(name = "gt apps", err, skip(self, core, _matches))]
     async fn run(
         &self,
         core: &Core,
@@ -28,6 +29,10 @@ impl CommandRunnable for AppsCommand {
         Ok(0)
     }
 
+    #[tracing::instrument(
+        name = "gt complete -- gt apps",
+        skip(self, _core, _completer, _matches)
+    )]
     async fn complete(&self, _core: &Core, _completer: &Completer, _matches: &ArgMatches) {}
 }
 

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -29,6 +29,7 @@ impl Command for AuthCommand {
 
 #[async_trait]
 impl CommandRunnable for AuthCommand {
+    #[tracing::instrument(name = "gt auth", err, skip(self, core, matches))]
     async fn run(
         &self,
         core: &Core,
@@ -59,6 +60,7 @@ impl CommandRunnable for AuthCommand {
         Ok(0)
     }
 
+    #[tracing::instrument(name = "gt complete -- gt auth", skip(self, core, completer, _matches))]
     async fn complete(&self, core: &Core, completer: &Completer, _matches: &ArgMatches) {
         completer.offer_many(core.config().get_services().map(|s| &s.name));
     }

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -25,6 +25,7 @@ impl Command for CloneCommand {
 
 #[async_trait]
 impl CommandRunnable for CloneCommand {
+    #[tracing::instrument(name = "gt clone", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         let repo_name = matches.value_of("repo").ok_or(errors::user(
             "You didn't specify the repository you wanted to clone.",
@@ -42,6 +43,10 @@ impl CommandRunnable for CloneCommand {
         Ok(0)
     }
 
+    #[tracing::instrument(
+        name = "gt complete -- gt clone",
+        skip(self, core, completer, _matches)
+    )]
     async fn complete(&self, core: &Core, completer: &Completer, _matches: &ArgMatches) {
         completer.offer_many(core.config().get_apps().map(|a| a.get_name()));
 

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -24,6 +24,7 @@ impl Command for CompleteCommand {
 
 #[async_trait]
 impl CommandRunnable for CompleteCommand {
+    #[tracing::instrument(name = "gt complete", err, skip(self, core, matches))]
     async fn run(
         &self,
         core: &Core,
@@ -48,6 +49,10 @@ where {
         Ok(0)
     }
 
+    #[tracing::instrument(
+        name = "gt complete -- gt complete",
+        skip(self, _core, completer, _matches)
+    )]
     async fn complete(&self, _core: &Core, completer: &Completer, _matches: &ArgMatches) {
         completer.offer("--position");
     }

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -73,6 +73,7 @@ impl Command for ConfigCommand {
 
 #[async_trait]
 impl CommandRunnable for ConfigCommand {
+    #[tracing::instrument(name = "gt config", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         let mut output = core.output();
 
@@ -225,6 +226,10 @@ impl CommandRunnable for ConfigCommand {
         Ok(0)
     }
 
+    #[tracing::instrument(
+        name = "gt complete -- gt config",
+        skip(self, core, completer, matches)
+    )]
     async fn complete(&self, core: &Core, completer: &Completer, matches: &ArgMatches) {
         match matches.subcommand() {
             Some(("list", _)) => {}

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -18,6 +18,7 @@ impl Command for DoctorCommand {
 
 #[async_trait]
 impl CommandRunnable for DoctorCommand {
+    #[tracing::instrument(name = "gt doctor", err, skip(self, core, _matches))]
     async fn run(
         &self,
         core: &Core,
@@ -99,6 +100,10 @@ impl CommandRunnable for DoctorCommand {
         Ok(0)
     }
 
+    #[tracing::instrument(
+        name = "gt complete -- gt doctor",
+        skip(self, _core, _completer, _matches)
+    )]
     async fn complete(&self, _core: &Core, _completer: &Completer, _matches: &clap::ArgMatches) {}
 }
 

--- a/src/commands/fix.rs
+++ b/src/commands/fix.rs
@@ -32,6 +32,7 @@ impl Command for FixCommand {
 
 #[async_trait]
 impl CommandRunnable for FixCommand {
+    #[tracing::instrument(name = "gt fix", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         let tasks = sequence![
             GitRemote { name: "origin" },
@@ -69,6 +70,7 @@ impl CommandRunnable for FixCommand {
         Ok(0)
     }
 
+    #[tracing::instrument(name = "gt complete -- gt fix", skip(self, core, completer, _matches))]
     async fn complete(&self, core: &Core, completer: &Completer, _matches: &ArgMatches) {
         completer.offer("--all");
         completer.offer("--no-create-remote");

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -9,6 +9,7 @@ pub enum LaunchTarget<'a> {
     None,
 }
 
+#[tracing::instrument(skip(core))]
 pub fn get_launch_app<'a>(
     core: &'a Core,
     first: Option<&'a str>,

--- a/src/commands/ignore.rs
+++ b/src/commands/ignore.rs
@@ -33,6 +33,7 @@ impl Command for IgnoreCommand {
 
 #[async_trait]
 impl CommandRunnable for IgnoreCommand {
+    #[tracing::instrument(name = "gt ignore", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         let mut output = core.output();
 
@@ -69,6 +70,10 @@ impl CommandRunnable for IgnoreCommand {
         Ok(0)
     }
 
+    #[tracing::instrument(
+        name = "gt complete -- gt ignore",
+        skip(self, core, completer, _matches)
+    )]
     async fn complete(&self, core: &Core, completer: &Completer, _matches: &ArgMatches) {
         match online::gitignore::list(core).await {
             Ok(langs) => completer.offer_many(langs),

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -24,6 +24,7 @@ impl Command for InfoCommand {
 
 #[async_trait]
 impl CommandRunnable for InfoCommand {
+    #[tracing::instrument(name = "gt info", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         let mut output = core.output();
         let repo = match matches.value_of("repo") {
@@ -49,6 +50,7 @@ impl CommandRunnable for InfoCommand {
         Ok(0)
     }
 
+    #[tracing::instrument(name = "gt complete -- gt info", skip(self, core, completer, _matches))]
     async fn complete(&self, core: &Core, completer: &Completer, _matches: &ArgMatches) {
         completer.offer_many(core.config().get_aliases().map(|(a, _)| a));
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -31,6 +31,7 @@ impl Command for ListCommand {
 
 #[async_trait]
 impl CommandRunnable for ListCommand {
+    #[tracing::instrument(name = "gt list", err, skip(self, core, matches))]
     async fn run(
         &self,
         core: &Core,
@@ -104,6 +105,10 @@ URLs:
         Ok(0)
     }
 
+    #[tracing::instrument(
+        name = "gt complete -- gt list",
+        skip(self, _core, completer, _matches)
+    )]
     async fn complete(&self, _core: &Core, completer: &Completer, _matches: &ArgMatches) {
         completer.offer_many(vec!["--quiet", "-q", "--full", "-f"]);
     }

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -38,6 +38,7 @@ impl Command for NewCommand {
 
 #[async_trait]
 impl CommandRunnable for NewCommand {
+    #[tracing::instrument(name = "gt new", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         let repo = match matches.value_of("repo") {
             Some(name) => core.resolver().get_best_repo(name)?,
@@ -74,6 +75,7 @@ impl CommandRunnable for NewCommand {
         Ok(0)
     }
 
+    #[tracing::instrument(name = "gt complete -- gt new", skip(self, core, completer, _matches))]
     async fn complete(&self, core: &Core, completer: &Completer, _matches: &ArgMatches) {
         completer.offer("--open");
         completer.offer("--no-create-remote");

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -38,6 +38,7 @@ New applications can be configured either by making changes to your configuratio
 
 #[async_trait]
 impl CommandRunnable for OpenCommand {
+    #[tracing::instrument(name = "gt open", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         if core.config().get_config_file().is_none() {
             warn!("No configuration file has been loaded, continuing with defaults.");
@@ -91,6 +92,10 @@ impl CommandRunnable for OpenCommand {
         Ok(status)
     }
 
+    #[tracing::instrument(
+        name = "gt complete -- gt complete",
+        skip(self, core, completer, _matches)
+    )]
     async fn complete(&self, core: &Core, completer: &Completer, _matches: &ArgMatches) {
         completer.offer("--create");
         completer.offer("--no-create-remote");

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -36,6 +36,7 @@ impl Command for PruneCommand {
 
 #[async_trait]
 impl CommandRunnable for PruneCommand {
+    #[tracing::instrument(name = "gt prune", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         let repo = core.resolver().get_current_repo()?;
 
@@ -91,6 +92,10 @@ impl CommandRunnable for PruneCommand {
         Ok(0)
     }
 
+    #[tracing::instrument(
+        name = "gt complete -- gt prune",
+        skip(self, core, completer, _matches)
+    )]
     async fn complete(&self, core: &Core, completer: &Completer, _matches: &ArgMatches) {
         if let Ok(repo) = core.resolver().get_current_repo() {
             completer.offer("--yes");

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -25,6 +25,7 @@ impl Command for RemoveCommand {
 
 #[async_trait]
 impl CommandRunnable for RemoveCommand {
+    #[tracing::instrument(name = "gt remove", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         let repo_name = matches.value_of("repo").ok_or_else(|| {
             errors::user(
@@ -48,6 +49,10 @@ impl CommandRunnable for RemoveCommand {
         Ok(0)
     }
 
+    #[tracing::instrument(
+        name = "gt complete -- gt remove",
+        skip(self, core, completer, _matches)
+    )]
     async fn complete(&self, core: &Core, completer: &Completer, _matches: &ArgMatches) {
         completer.offer("--create");
         completer.offer("--no-create-remote");

--- a/src/commands/scratch.rs
+++ b/src/commands/scratch.rs
@@ -30,6 +30,7 @@ impl Command for ScratchCommand {
 
 #[async_trait]
 impl CommandRunnable for ScratchCommand {
+    #[tracing::instrument(name = "gt scratch", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         let (app, scratchpad) = match helpers::get_launch_app(
             core,
@@ -66,6 +67,10 @@ impl CommandRunnable for ScratchCommand {
         return Ok(status);
     }
 
+    #[tracing::instrument(
+        name = "gt complete -- gt scratch",
+        skip(self, core, completer, _matches)
+    )]
     async fn complete(&self, core: &Core, completer: &Completer, _matches: &ArgMatches) {
         completer.offer_many(core.config().get_apps().map(|a| a.get_name()));
 

--- a/src/commands/services.rs
+++ b/src/commands/services.rs
@@ -16,6 +16,7 @@ impl Command for ServicesCommand {
 
 #[async_trait]
 impl CommandRunnable for ServicesCommand {
+    #[tracing::instrument(name = "gt services", err, skip(self, core, _matches))]
     async fn run(
         &self,
         core: &Core,
@@ -30,6 +31,10 @@ impl CommandRunnable for ServicesCommand {
         Ok(0)
     }
 
+    #[tracing::instrument(
+        name = "gt complete -- gt services",
+        skip(self, _core, _completer, _matches)
+    )]
     async fn complete(&self, _core: &Core, _completer: &Completer, _matches: &ArgMatches) {}
 }
 

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -33,6 +33,7 @@ impl Command for SetupCommand {
 
 #[async_trait]
 impl CommandRunnable for SetupCommand {
+    #[tracing::instrument(name = "gt setup", err, skip(self, core, matches))]
     async fn run(
         &self,
         core: &Core,
@@ -101,6 +102,10 @@ impl CommandRunnable for SetupCommand {
         Ok(0)
     }
 
+    #[tracing::instrument(
+        name = "gt complete -- gt setup",
+        skip(self, _core, _completer, _matches)
+    )]
     async fn complete(&self, _core: &Core, _completer: &Completer, _matches: &ArgMatches) {}
 }
 

--- a/src/commands/shell_init.rs
+++ b/src/commands/shell_init.rs
@@ -35,6 +35,7 @@ impl Command for ShellInitCommand {
 
 #[async_trait]
 impl CommandRunnable for ShellInitCommand {
+    #[tracing::instrument(name = "gt shell-init", err, skip(self, core, matches))]
     async fn run(
         &self,
         core: &Core,
@@ -66,7 +67,10 @@ where {
 
         Ok(0)
     }
-
+    #[tracing::instrument(
+        name = "gt complete -- gt shell-init",
+        skip(self, _core, completer, _matches)
+    )]
     async fn complete(&self, _core: &Core, completer: &Completer, _matches: &ArgMatches) {
         let shells = get_shells();
         completer.offer_many(shells.iter().map(|s| s.get_name()));

--- a/src/commands/switch.rs
+++ b/src/commands/switch.rs
@@ -37,6 +37,7 @@ impl Command for SwitchCommand {
 
 #[async_trait]
 impl CommandRunnable for SwitchCommand {
+    #[tracing::instrument(name = "gt switch", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         let repo = core.resolver().get_current_repo()?;
 
@@ -64,7 +65,10 @@ impl CommandRunnable for SwitchCommand {
 
         Ok(0)
     }
-
+    #[tracing::instrument(
+        name = "gt complete -- gt switch",
+        skip(self, core, completer, _matches)
+    )]
     async fn complete(&self, core: &Core, completer: &Completer, _matches: &ArgMatches) {
         if let Ok(repo) = core.resolver().get_current_repo() {
             completer.offer("--create");

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -32,6 +32,7 @@ impl Command for UpdateCommand {
 
 #[async_trait]
 impl CommandRunnable for UpdateCommand {
+    #[tracing::instrument(name = "gt update", err, skip(self, core, matches))]
     async fn run(
         &self,
         core: &Core,
@@ -138,6 +139,10 @@ where {
         Ok(0)
     }
 
+    #[tracing::instrument(
+        name = "gt complete -- gt update",
+        skip(self, core, completer, _matches)
+    )]
     async fn complete(&self, core: &Core, completer: &Completer, _matches: &ArgMatches) {
         let manager: UpdateManager<GitHubSource> = UpdateManager::default();
 

--- a/src/console/prompt.rs
+++ b/src/console/prompt.rs
@@ -2,6 +2,7 @@
 use mocktopus::{macros::*, mocking::*};
 
 #[cfg_attr(test, mockable)]
+#[tracing::instrument]
 pub fn prompt(msg: &str, default: &str) -> String {
     match write!(super::output::output(), "{}", msg) {
         Ok(_) => (),

--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -19,17 +19,20 @@ impl From<Arc<Config>> for KeyChain {
 #[cfg(feature = "auth")]
 #[cfg_attr(test, mockable)]
 impl KeyChain {
+    #[tracing::instrument(err, skip(self))]
     pub fn get_token(&self, service: &str) -> Result<String, Error> {
         let token = keyring::Entry::new("git-tool", service).get_password()?;
 
         Ok(token)
     }
 
+    #[tracing::instrument(err, skip(self, token))]
     pub fn set_token(&self, service: &str, token: &str) -> Result<(), Error> {
         keyring::Entry::new("git-tool", service).set_password(token)?;
         Ok(())
     }
 
+    #[tracing::instrument(err, skip(self))]
     pub fn remove_token(&self, service: &str) -> Result<(), Error> {
         keyring::Entry::new("git-tool", service).delete_password()?;
         Ok(())

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -80,6 +80,7 @@ impl Config {
         into
     }
 
+    #[tracing::instrument(err, skip(self))]
     pub fn apply_template(
         &self,
         template: EntryConfig,
@@ -152,6 +153,7 @@ impl Config {
             })
     }
 
+    #[tracing::instrument(err, skip(path))]
     pub fn from_file(path: &path::Path) -> Result<Self, errors::Error> {
         let f = std::fs::File::open(path).map_err(|err| errors::user_with_internal(
             &format!("We could not open your Git-Tool config file '{}' for reading.", path.display()),

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -153,7 +153,7 @@ impl Config {
             })
     }
 
-    #[tracing::instrument(err, skip(path))]
+    #[tracing::instrument(name = "config:from_file" err, skip(path))]
     pub fn from_file(path: &path::Path) -> Result<Self, errors::Error> {
         let f = std::fs::File::open(path).map_err(|err| errors::user_with_internal(
             &format!("We could not open your Git-Tool config file '{}' for reading.", path.display()),

--- a/src/core/features.rs
+++ b/src/core/features.rs
@@ -62,7 +62,7 @@ impl FeaturesBuilder {
     pub fn with_defaults(self) -> Self {
         self.with(CREATE_REMOTE, true)
             .with(CREATE_REMOTE_PRIVATE, true)
-            .with(TELEMETRY, true)
+            .with(TELEMETRY, false)
     }
 
     pub fn with_features(self, features: &Features) -> Self {

--- a/src/core/files.rs
+++ b/src/core/files.rs
@@ -17,6 +17,7 @@ impl From<Arc<Config>> for FileSource {
 }
 
 impl FileSource {
+    #[tracing::instrument(err, skip(self, path))]
     async fn read(&self, path: &std::path::Path) -> Result<String, Error> {
         let mut file = tokio::fs::File::open(path).await?;
 
@@ -26,6 +27,7 @@ impl FileSource {
         Ok(String::from_utf8(buffer)?)
     }
 
+    #[tracing::instrument(err, skip(self, path, content))]
     async fn write(&self, path: &std::path::Path, content: String) -> Result<(), Error> {
         let mut file = tokio::fs::File::create(path).await?;
 

--- a/src/core/http.rs
+++ b/src/core/http.rs
@@ -10,13 +10,21 @@ use mocktopus::macros::*;
 #[cfg_attr(test, mockable)]
 pub struct HttpClient {}
 
+impl std::fmt::Debug for HttpClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "HttpClient")
+    }
+}
+
 #[cfg_attr(test, mockable)]
 impl HttpClient {
+    #[tracing::instrument(err, skip(uri))]
     pub async fn get(&self, uri: reqwest::Url) -> Result<Response, Error> {
         let req = Request::new(reqwest::Method::GET, uri);
         Ok(self.request(req).await?)
     }
 
+    #[tracing::instrument(err, skip(req))]
     pub async fn request(&self, req: Request) -> Result<Response, Error> {
         let client = Client::new();
         Ok(client.execute(req).await?)

--- a/src/core/launcher.rs
+++ b/src/core/launcher.rs
@@ -28,8 +28,15 @@ impl From<Arc<Config>> for Launcher {
     }
 }
 
+impl std::fmt::Debug for Launcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Launcher")
+    }
+}
+
 #[cfg_attr(test, mockable)]
 impl Launcher {
+    #[tracing::instrument(name = "launch", err, ret, skip(t))]
     pub async fn run(&self, a: &app::App, t: &(dyn Target + Send + Sync)) -> Result<i32, Error> {
         let context = t.template_context(&self.config);
 

--- a/src/core/prompt.rs
+++ b/src/core/prompt.rs
@@ -20,6 +20,7 @@ impl Prompter {
         }
     }
 
+    #[tracing::instrument(err, skip(self, validate))]
     pub fn prompt<V>(&mut self, message: &str, validate: V) -> Result<Option<String>, Error>
     where
         V: Fn(&str) -> bool,

--- a/src/core/repo.rs
+++ b/src/core/repo.rs
@@ -56,3 +56,9 @@ impl Repo {
         self.path.join(".git").is_dir()
     }
 }
+
+impl std::fmt::Display for Repo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", &self.service, self.get_full_name())
+    }
+}

--- a/src/core/resolver.rs
+++ b/src/core/resolver.rs
@@ -20,6 +20,7 @@ impl From<Arc<Config>> for Resolver {
 
 #[cfg_attr(test, mockable)]
 impl Resolver {
+    #[tracing::instrument(err, skip(self))]
     pub fn get_scratchpads(&self) -> Result<Vec<Scratchpad>, Error> {
         let dirs = self.config.get_scratch_directory().read_dir().map_err(|err| errors::user_with_internal(
             &format!("Could not retrieve the list of directories within your scratchpad directory '{}' due to an OS-level error.", self.config.get_scratch_directory().display()),
@@ -49,6 +50,7 @@ impl Resolver {
         Ok(scratchpads)
     }
 
+    #[tracing::instrument(err, skip(self, name))]
     pub fn get_scratchpad(&self, name: &str) -> Result<Scratchpad, Error> {
         Ok(Scratchpad::new(
             name.clone(),
@@ -56,12 +58,14 @@ impl Resolver {
         ))
     }
 
+    #[tracing::instrument(err, skip(self))]
     pub fn get_current_scratchpad(&self) -> Result<Scratchpad, Error> {
         let time = Local::now();
 
         self.get_scratchpad(&time.format("%Yw%V").to_string())
     }
 
+    #[tracing::instrument(err, skip(self))]
     pub fn get_current_repo(&self) -> Result<Repo, Error> {
         let cwd = env::current_dir().map_err(|err| errors::system_with_internal(
             "Could not determine your current working directory due to an OS-level error.",
@@ -78,6 +82,7 @@ impl Resolver {
         }
     }
 
+    #[tracing::instrument(err, skip(self, path))]
     pub fn get_repo_from_path(&self, path: &std::path::Path) -> Result<Repo, Error> {
         let dev_dir = self.config.get_dev_directory().canonicalize().map_err(|err| errors::user_with_internal(
             &format!("Could not determine the canonical path for your dev directory '{}' due to an OS-level error.", self.config.get_dev_directory().display()),
@@ -115,10 +120,12 @@ impl Resolver {
         }
     }
 
+    #[tracing::instrument(err, skip(self, repo))]
     pub fn get_repo(&self, repo: &str) -> Result<Repo, Error> {
         repo_from_str(&self.config, repo, true)
     }
 
+    #[tracing::instrument(err, skip(self, name))]
     pub fn get_best_repo(&self, name: &str) -> Result<Repo, Error> {
         let true_name = self.config.get_alias(name).unwrap_or(name.to_string());
 
@@ -149,6 +156,7 @@ impl Resolver {
         }
     }
 
+    #[tracing::instrument(err, skip(self))]
     pub fn get_repos(&self) -> Result<Vec<Repo>, Error> {
         let mut repos = vec![];
 
@@ -182,6 +190,7 @@ impl Resolver {
         Ok(repos)
     }
 
+    #[tracing::instrument(err, skip(self))]
     pub fn get_repos_for(&self, svc: &Service) -> Result<Vec<Repo>, Error> {
         if !&svc.pattern.split("/").all(|p| p == "*") {
             return Err(errors::user(
@@ -281,6 +290,7 @@ fn get_child_directories(from: &std::path::PathBuf, pattern: &str) -> Vec<std::p
 }
 
 #[cfg_attr(test, mockable)]
+#[tracing::instrument(skip(from))]
 fn get_directory_tree_to_depth(from: &std::path::PathBuf, depth: usize) -> Vec<std::path::PathBuf> {
     if depth == 0 {
         return vec![from.clone()];

--- a/src/core/scratchpad.rs
+++ b/src/core/scratchpad.rs
@@ -34,3 +34,9 @@ impl Scratchpad {
         }
     }
 }
+
+impl std::fmt::Display for Scratchpad {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "scratch:{}", &self.full_name)
+    }
+}

--- a/src/core/service.rs
+++ b/src/core/service.rs
@@ -28,6 +28,12 @@ impl Service {
     }
 }
 
+impl std::fmt::Display for Service {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &self.name)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::core::ServiceAPI;

--- a/src/core/templates.rs
+++ b/src/core/templates.rs
@@ -13,6 +13,7 @@ macro_rules! map(
      };
 );
 
+#[tracing::instrument(err, skip(context))]
 pub fn render(tmpl: &str, context: Value) -> Result<String, errors::Error> {
     template(tmpl, context).map_err(|e| errors::user_with_internal(
         format!("We couldn't render your template '{}'.", tmpl).as_str(),
@@ -20,6 +21,7 @@ pub fn render(tmpl: &str, context: Value) -> Result<String, errors::Error> {
         errors::detailed_message(&e.to_string())))
 }
 
+#[tracing::instrument(err, skip(context, items))]
 pub fn render_list<S: AsRef<str>>(
     items: Vec<S>,
     context: Value,

--- a/src/git/cmd.rs
+++ b/src/git/cmd.rs
@@ -1,8 +1,9 @@
 use crate::errors;
+use opentelemetry::trace::SpanKind;
 use std::process::Stdio;
 use tokio::process::Command;
 
-#[tracing::instrument(err, skip(cmd))]
+#[tracing::instrument(err, skip(cmd), fields(otel.kind = %SpanKind::Client))]
 pub async fn git_cmd(cmd: &mut Command) -> Result<String, errors::Error> {
     let child = cmd.stdout(Stdio::piped()).spawn().map_err(|err| errors::user_with_internal(
         "Could not run git, which is a dependency of Git-Tool.",

--- a/src/git/cmd.rs
+++ b/src/git/cmd.rs
@@ -2,6 +2,7 @@ use crate::errors;
 use std::process::Stdio;
 use tokio::process::Command;
 
+#[tracing::instrument(err, skip(cmd))]
 pub async fn git_cmd(cmd: &mut Command) -> Result<String, errors::Error> {
     let child = cmd.stdout(Stdio::piped()).spawn().map_err(|err| errors::user_with_internal(
         "Could not run git, which is a dependency of Git-Tool.",

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,9 +92,9 @@ async fn run<'a>(
 
     let core = Arc::new(core_builder.build());
 
-    // If telemetry is disabled in the config file, then turn it off here.
-    if !core.config().get_features().has(features::TELEMETRY) {
-        telemetry::set_enabled(false);
+    // If telemetry is enabled in the config file, then turn it on here.
+    if core.config().get_features().has(features::TELEMETRY) {
+        telemetry::set_enabled(true);
     }
 
     // Legacy update interoperability for compatibility with the Golang implementation

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ extern crate gtmpl;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
-extern crate log;
+extern crate tracing;
 extern crate sentry;
 #[macro_use]
 extern crate serde_json;
@@ -77,6 +77,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     }
 }
 
+#[tracing::instrument(err, ret, skip(app, commands, matches))]
 async fn run<'a>(
     mut app: clap::Command<'a>,
     commands: Vec<Arc<dyn CommandRunnable>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     }
 }
 
-#[tracing::instrument(err, ret, skip(app, commands, matches))]
+#[tracing::instrument(err, ret, skip(app, commands, matches), fields(command=matches.subcommand_name().unwrap_or("<none>")))]
 async fn run<'a>(
     mut app: clap::Command<'a>,
     commands: Vec<Arc<dyn CommandRunnable>>,

--- a/src/online/gitignore.rs
+++ b/src/online/gitignore.rs
@@ -1,6 +1,7 @@
 use super::{errors, Error};
 use crate::core::Core;
 
+#[tracing::instrument(err, skip(core, content))]
 pub async fn add_or_update(
     core: &Core,
     content: &str,
@@ -31,6 +32,7 @@ pub async fn add_or_update(
     Ok(managed.into())
 }
 
+#[tracing::instrument(err, skip(core))]
 pub async fn list(core: &Core) -> Result<Vec<String>, Error> {
     let uri = "https://www.toptal.com/developers/gitignore/api/list"
         .parse()
@@ -54,6 +56,7 @@ pub async fn list(core: &Core) -> Result<Vec<String>, Error> {
         .collect())
 }
 
+#[tracing::instrument(err, skip(core))]
 pub async fn ignore(core: &Core, langs: Vec<&str>) -> Result<String, Error> {
     if langs.is_empty() {
         return Ok("".to_string());

--- a/src/online/registry/file_registry.rs
+++ b/src/online/registry/file_registry.rs
@@ -15,6 +15,7 @@ impl FileRegistry {
 
 #[async_trait::async_trait]
 impl Registry for FileRegistry {
+    #[tracing::instrument(err, ret, skip(self, _core))]
     async fn get_entries(&self, _core: &Core) -> Result<Vec<String>, Error> {
         let mut entries = Vec::new();
 
@@ -80,6 +81,7 @@ impl Registry for FileRegistry {
         Ok(entries)
     }
 
+    #[tracing::instrument(err, ret, skip(self, _core))]
     async fn get_entry(&self, _core: &Core, id: &str) -> Result<Entry, Error> {
         let path = self.path.join(to_native_path(format!("{}.yaml", id)));
         let contents = read_to_string(&path).map_err(|err| {

--- a/src/online/registry/github_registry.rs
+++ b/src/online/registry/github_registry.rs
@@ -56,6 +56,7 @@ impl GitHubRegistry {
 
 #[async_trait::async_trait]
 impl Registry for GitHubRegistry {
+    #[tracing::instrument(err, ret, skip(self, core))]
     async fn get_entries(&self, core: &Core) -> Result<Vec<String>, Error> {
         let resp = self.get(core, "https://api.github.com/repos/SierraSoftworks/git-tool/git/trees/main?recursive=true").await?;
 
@@ -99,6 +100,7 @@ impl Registry for GitHubRegistry {
         }
     }
 
+    #[tracing::instrument(err, ret, skip(self, core))]
     async fn get_entry(&self, core: &Core, id: &str) -> Result<Entry, Error> {
         let resp = self
             .get(

--- a/src/online/registry/mod.rs
+++ b/src/online/registry/mod.rs
@@ -22,6 +22,12 @@ pub struct Entry {
     pub configs: Vec<EntryConfig>,
 }
 
+impl std::fmt::Display for Entry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &self.name)
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct EntryConfig {
     pub platform: String,

--- a/src/online/service/github.rs
+++ b/src/online/service/github.rs
@@ -27,6 +27,7 @@ impl OnlineService for GitHubService {
         Ok(())
     }
 
+    #[tracing::instrument(err, skip(self, core))]
     async fn ensure_created(
         &self,
         core: &Core,

--- a/src/tasks/create_remote.rs
+++ b/src/tasks/create_remote.rs
@@ -13,6 +13,7 @@ impl Default for CreateRemote {
 #[async_trait::async_trait]
 impl Task for CreateRemote {
     #[cfg(feature = "auth")]
+    #[tracing::instrument(name = "task:create_remote(repo)", err, skip(self, core))]
     async fn apply_repo(&self, core: &Core, repo: &core::Repo) -> Result<(), core::Error> {
         if !self.enabled {
             return Ok(());
@@ -43,10 +44,12 @@ impl Task for CreateRemote {
     }
 
     #[cfg(not(feature = "auth"))]
+    #[tracing::instrument(name = "task:create_remote(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, _repo: &core::Repo) -> Result<(), core::Error> {
         Ok(())
     }
 
+    #[tracing::instrument(name = "task:create_remote(scratchpad)", err, skip(self, _core))]
     async fn apply_scratchpad(
         &self,
         _core: &Core,

--- a/src/tasks/git_add.rs
+++ b/src/tasks/git_add.rs
@@ -7,10 +7,12 @@ pub struct GitAdd<'a> {
 
 #[async_trait::async_trait]
 impl<'a> Task for GitAdd<'a> {
+    #[tracing::instrument(name = "task:git_add(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &core::Repo) -> Result<(), core::Error> {
         git::git_add(&repo.get_path(), &self.paths).await
     }
 
+    #[tracing::instrument(name = "task:git_add(scratchpad)", err, skip(self, _core))]
     async fn apply_scratchpad(
         &self,
         _core: &Core,

--- a/src/tasks/git_checkout.rs
+++ b/src/tasks/git_checkout.rs
@@ -7,10 +7,12 @@ pub struct GitCheckout<'a> {
 
 #[async_trait::async_trait]
 impl<'a> Task for GitCheckout<'a> {
+    #[tracing::instrument(name = "task:git_checkout(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &core::Repo) -> Result<(), core::Error> {
         git::git_checkout(&repo.get_path(), &self.branch).await
     }
 
+    #[tracing::instrument(name = "task:git_checkout(scratchpad)", err, skip(self, _core))]
     async fn apply_scratchpad(
         &self,
         _core: &Core,

--- a/src/tasks/git_clone.rs
+++ b/src/tasks/git_clone.rs
@@ -5,6 +5,7 @@ pub struct GitClone {}
 
 #[async_trait::async_trait]
 impl Task for GitClone {
+    #[tracing::instrument(name = "task:git_clone(repo)", err, skip(self, core))]
     async fn apply_repo(&self, core: &Core, repo: &core::Repo) -> Result<(), core::Error> {
         if repo.exists() {
             return Ok(());
@@ -21,6 +22,7 @@ impl Task for GitClone {
         git::git_clone(&repo.get_path(), &url).await
     }
 
+    #[tracing::instrument(name = "task:git_clone(scratchpad)", err, skip(self, _core))]
     async fn apply_scratchpad(
         &self,
         _core: &Core,

--- a/src/tasks/git_commit.rs
+++ b/src/tasks/git_commit.rs
@@ -8,10 +8,12 @@ pub struct GitCommit<'a> {
 
 #[async_trait::async_trait]
 impl<'a> Task for GitCommit<'a> {
+    #[tracing::instrument(name = "task:git_commit(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &core::Repo) -> Result<(), core::Error> {
         git::git_commit(&repo.get_path(), self.message, &self.paths).await
     }
 
+    #[tracing::instrument(name = "task:git_commit(scratchpad)", err, skip(self, _core))]
     async fn apply_scratchpad(
         &self,
         _core: &Core,

--- a/src/tasks/git_init.rs
+++ b/src/tasks/git_init.rs
@@ -5,10 +5,12 @@ pub struct GitInit {}
 
 #[async_trait::async_trait]
 impl Task for GitInit {
+    #[tracing::instrument(name = "task:git_init(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &core::Repo) -> Result<(), core::Error> {
         git::git_init(&repo.get_path()).await
     }
 
+    #[tracing::instrument(name = "task:git_init(scratchpad)", err, skip(self, _core))]
     async fn apply_scratchpad(
         &self,
         _core: &Core,

--- a/src/tasks/git_remote.rs
+++ b/src/tasks/git_remote.rs
@@ -13,6 +13,7 @@ impl Default for GitRemote<'static> {
 
 #[async_trait::async_trait]
 impl<'a> Task for GitRemote<'a> {
+    #[tracing::instrument(name = "task:git_remote(repo)", err, skip(self, core))]
     async fn apply_repo(&self, core: &Core, repo: &core::Repo) -> Result<(), core::Error> {
         let service = core.config().get_service(&repo.service).ok_or(
             errors::user(
@@ -33,6 +34,7 @@ impl<'a> Task for GitRemote<'a> {
         }
     }
 
+    #[tracing::instrument(name = "task:git_remote(scratchpad)", err, skip(self, _core))]
     async fn apply_scratchpad(
         &self,
         _core: &Core,

--- a/src/tasks/git_switch.rs
+++ b/src/tasks/git_switch.rs
@@ -8,6 +8,7 @@ pub struct GitSwitch {
 
 #[async_trait::async_trait]
 impl Task for GitSwitch {
+    #[tracing::instrument(name = "task:git_switch(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &core::Repo) -> Result<(), core::Error> {
         let mut create = self.create_if_missing;
 
@@ -23,6 +24,7 @@ impl Task for GitSwitch {
         git::git_switch(&repo.get_path(), &self.branch, create).await
     }
 
+    #[tracing::instrument(name = "task:git_switch(scratchpad)", err, skip(self, _core))]
     async fn apply_scratchpad(
         &self,
         _core: &Core,

--- a/src/tasks/new_folder.rs
+++ b/src/tasks/new_folder.rs
@@ -6,6 +6,7 @@ pub struct NewFolder {}
 
 #[async_trait::async_trait]
 impl Task for NewFolder {
+    #[tracing::instrument(name = "task:new_folder(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &core::Repo) -> Result<(), core::Error> {
         let path = repo.get_path();
 
@@ -23,6 +24,7 @@ impl Task for NewFolder {
         Ok(())
     }
 
+    #[tracing::instrument(name = "task:new_folder(scratchpad)", err, skip(self, _core))]
     async fn apply_scratchpad(
         &self,
         _core: &Core,

--- a/src/tasks/sequence.rs
+++ b/src/tasks/sequence.rs
@@ -13,6 +13,7 @@ impl Sequence {
 
 #[async_trait]
 impl Task for Sequence {
+    #[tracing::instrument(name = "task:sequence(repo)", err, skip(self, core))]
     async fn apply_repo(&self, core: &Core, repo: &core::Repo) -> Result<(), core::Error> {
         for task in self.tasks.iter() {
             task.apply_repo(core, repo).await?;
@@ -21,6 +22,7 @@ impl Task for Sequence {
         Ok(())
     }
 
+    #[tracing::instrument(name = "task:sequence(scratchpad)", err, skip(self, core))]
     async fn apply_scratchpad(
         &self,
         core: &Core,

--- a/src/tasks/write_file.rs
+++ b/src/tasks/write_file.rs
@@ -10,6 +10,7 @@ pub struct WriteFile<'a> {
 
 #[async_trait::async_trait]
 impl<'a> Task for WriteFile<'a> {
+    #[tracing::instrument(name = "task:write_file(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &core::Repo) -> Result<(), core::Error> {
         let path = repo.get_path().join(&self.path);
 
@@ -32,6 +33,7 @@ impl<'a> Task for WriteFile<'a> {
         Ok(())
     }
 
+    #[tracing::instrument(name = "task:write_file(scratchpad)", err, skip(self, _core))]
     async fn apply_scratchpad(
         &self,
         _core: &Core,

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -78,6 +78,9 @@ impl Session {
 
         tracing_subscriber::registry()
             .with(tracing_subscriber::filter::LevelFilter::DEBUG)
+            .with(tracing_subscriber::filter::filter_fn(|_metadata| {
+                is_enabled()
+            }))
             .with(tracing_opentelemetry::layer().with_tracer(tracer))
             .init();
 

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -6,7 +6,7 @@ use tracing_subscriber::prelude::*;
 use crate::core::Error;
 
 lazy_static! {
-    static ref ENABLED: RwLock<bool> = RwLock::new(true);
+    static ref ENABLED: RwLock<bool> = RwLock::new(false);
 }
 
 pub fn is_enabled() -> bool {

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -5,8 +5,10 @@ use tracing_subscriber::prelude::*;
 
 use crate::core::Error;
 
+// NOTE: We need to enable this initially so that we can construct an enabled root span
+//       however we disable it immediately after loading the configuration file if required.
 lazy_static! {
-    static ref ENABLED: RwLock<bool> = RwLock::new(false);
+    static ref ENABLED: RwLock<bool> = RwLock::new(true);
 }
 
 pub fn is_enabled() -> bool {
@@ -78,9 +80,9 @@ impl Session {
 
         tracing_subscriber::registry()
             .with(tracing_subscriber::filter::LevelFilter::DEBUG)
-            .with(tracing_subscriber::filter::filter_fn(|_metadata| {
-                is_enabled()
-            }))
+            .with(tracing_subscriber::filter::dynamic_filter_fn(
+                |_metadata, _ctx| is_enabled(),
+            ))
             .with(tracing_opentelemetry::layer().with_tracer(tracer))
             .init();
 

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,6 +1,7 @@
-use std::sync::{Arc, RwLock};
-
+use opentelemetry_otlp::WithExportConfig;
 use sentry::ClientInitGuard;
+use std::sync::{Arc, RwLock};
+use tracing_subscriber::prelude::*;
 
 use crate::core::Error;
 
@@ -21,16 +22,13 @@ pub struct Session {
 
 impl Session {
     pub fn new() -> Self {
-        let logger = sentry::integrations::log::SentryLogger::new();
-        log::set_boxed_logger(Box::new(logger)).unwrap();
-        log::set_max_level(log::LevelFilter::Debug);
-
         let raven = sentry::init((
             "https://0787127414b24323be5a3d34767cb9b8@o219072.ingest.sentry.io/1486938",
             sentry::ClientOptions {
                 release: Some(version!("git-tool@v").into()),
                 default_integrations: true,
                 attach_stacktrace: true,
+                send_default_pii: false,
                 before_send: Some(Arc::new(|mut event| {
                     if !is_enabled() {
                         None
@@ -45,12 +43,52 @@ impl Session {
             },
         ));
 
+        let mut tracing_metadata = tonic::metadata::MetadataMap::new();
+        tracing_metadata.insert(
+            "x-honeycomb-team",
+            "fd8BghJ1Qd7xBU9s4ULEBC".parse().unwrap(),
+        );
+
+        let mut tls_config = rustls::ClientConfig::new();
+        tls_config
+            .root_store
+            .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+
+        tls_config.set_protocols(&vec!["h2".to_string().into()]);
+
+        let tracer = opentelemetry_otlp::new_pipeline()
+            .tracing()
+            .with_exporter(
+                opentelemetry_otlp::new_exporter()
+                    .tonic()
+                    .with_endpoint("https://api.honeycomb.io:443")
+                    .with_metadata(tracing_metadata)
+                    .with_tls_config(
+                        tonic::transport::ClientTlsConfig::new().rustls_client_config(tls_config),
+                    ),
+            )
+            .with_trace_config(opentelemetry::sdk::trace::config().with_resource(
+                opentelemetry::sdk::Resource::new(vec![opentelemetry::KeyValue::new(
+                    "service.name",
+                    "git-tool",
+                )]),
+            ))
+            .install_batch(opentelemetry::runtime::Tokio)
+            .unwrap();
+
+        tracing_subscriber::registry()
+            .with(tracing_subscriber::filter::LevelFilter::DEBUG)
+            .with(tracing_opentelemetry::layer().with_tracer(tracer))
+            .init();
+
         sentry::start_session();
 
         Self { raven }
     }
 
     pub fn complete(&self) {
+        opentelemetry::global::shutdown_tracer_provider();
+
         if !is_enabled() {
             return;
         }
@@ -60,6 +98,8 @@ impl Session {
     }
 
     pub fn crash(&self, err: Error) {
+        opentelemetry::global::shutdown_tracer_provider();
+
         if !is_enabled() {
             return;
         }

--- a/src/update/github.rs
+++ b/src/update/github.rs
@@ -22,6 +22,7 @@ impl Default for GitHubSource {
 
 #[async_trait::async_trait]
 impl Source for GitHubSource {
+    #[tracing::instrument(err, ret, skip(self, core))]
     async fn get_releases(&self, core: &Core) -> Result<Vec<Release>, crate::core::Error> {
         let uri = format!("https://api.github.com/repos/{}/releases", self.repo);
         info!("Making GET request to {} to check for new releases.", uri);
@@ -55,6 +56,7 @@ impl Source for GitHubSource {
         }
     }
 
+    #[tracing::instrument(err, skip(self, core, into))]
     async fn get_binary<W: std::io::Write + Send>(
         &self,
         core: &Core,
@@ -68,6 +70,12 @@ impl Source for GitHubSource {
         );
 
         self.download_to_file(core, &uri, into).await
+    }
+}
+
+impl std::fmt::Debug for GitHubSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "GitHub - {}", &self.repo)
     }
 }
 

--- a/src/update/manager.rs
+++ b/src/update/manager.rs
@@ -36,6 +36,7 @@ where
         self.source.get_releases(core).await
     }
 
+    #[tracing::instrument(err, ret, skip(self, core))]
     pub async fn update(&self, core: &Core, release: &Release) -> Result<bool, errors::Error> {
         let state = UpdateState {
             target_application: Some(self.target_application.clone()),
@@ -98,6 +99,7 @@ where
         self.resume(&state).await
     }
 
+    #[tracing::instrument(err, ret, skip(self))]
     pub async fn resume(&self, state: &UpdateState) -> Result<bool, errors::Error> {
         match state.phase {
             UpdatePhase::NoUpdate => Ok(false),
@@ -107,6 +109,7 @@ where
         }
     }
 
+    #[tracing::instrument(err, ret, skip(self))]
     async fn prepare(&self, state: &UpdateState) -> Result<bool, errors::Error> {
         let next_state = state.for_phase(UpdatePhase::Replace);
         let update_source = state.temporary_application.clone().ok_or(errors::system(
@@ -119,6 +122,7 @@ where
         Ok(true)
     }
 
+    #[tracing::instrument(err, ret, skip(self))]
     async fn replace(&self, state: &UpdateState) -> Result<bool, errors::Error> {
         let update_source = state.temporary_application.clone().ok_or(errors::system(
             "Could not locate the temporary update files needed to complete the update process (replace phase).",
@@ -140,6 +144,7 @@ where
         Ok(true)
     }
 
+    #[tracing::instrument(err, ret, skip(self))]
     async fn cleanup(&self, state: &UpdateState) -> Result<bool, errors::Error> {
         let update_source = state.temporary_application.clone().ok_or(errors::system(
             "Could not locate the temporary update files needed to complete the update process (cleanup phase).",
@@ -152,6 +157,7 @@ where
     }
 
     #[cfg(unix)]
+    #[tracing::instrument(err, skip(self, file))]
     fn prepare_app_file(&self, file: &std::path::Path) -> Result<(), errors::Error> {
         let mut perms = std::fs::metadata(file).map_err(|err| {
             errors::user_with_internal(
@@ -188,6 +194,7 @@ where
 
 #[cfg_attr(test, mockable)]
 impl<S: Source> UpdateManager<S> {
+    #[tracing::instrument(err, skip(self, app_path))]
     fn launch(&self, app_path: &Path, state: &UpdateState) -> Result<(), errors::Error> {
         let state_json = serde_json::to_string(state)?;
         let mut cmd = Command::new(app_path);
@@ -208,6 +215,7 @@ impl<S: Source> UpdateManager<S> {
         Ok(())
     }
 
+    #[tracing::instrument(err, skip(path))]
     async fn delete_file(&self, path: &Path) -> Result<(), errors::Error> {
         let max_retries = 10;
         let mut retries = max_retries;
@@ -229,6 +237,7 @@ impl<S: Source> UpdateManager<S> {
         Ok(())
     }
 
+    #[tracing::instrument(err, skip(from, to))]
     async fn copy_file(&self, from: &Path, to: &Path) -> Result<(), errors::Error> {
         let max_retries = 10;
         let mut retries = max_retries;
@@ -274,6 +283,15 @@ where
             source: S::default(),
             variant: ReleaseVariant::default(),
         }
+    }
+}
+
+impl<S> std::fmt::Debug for UpdateManager<S>
+where
+    S: Source,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?} ({})", &self.source, &self.variant)
     }
 }
 

--- a/src/update/release.rs
+++ b/src/update/release.rs
@@ -45,6 +45,15 @@ impl PartialEq<Release> for Release {
     }
 }
 
+impl std::fmt::Display for Release {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.prerelease {
+            false => write!(f, "{}", &self.id),
+            true => write!(f, "{}-beta", &self.id),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ReleaseVariant {
     pub id: String,
@@ -65,6 +74,12 @@ impl Default for ReleaseVariant {
 impl PartialEq<ReleaseVariant> for ReleaseVariant {
     fn eq(&self, other: &ReleaseVariant) -> bool {
         self.arch == other.arch && self.platform == other.platform
+    }
+}
+
+impl std::fmt::Display for ReleaseVariant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}-{}", &self.platform, &self.arch)
     }
 }
 

--- a/src/update/state.rs
+++ b/src/update/state.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::path::PathBuf;
 
 #[async_trait::async_trait]
-pub trait Source: Default + Send + Sync {
+pub trait Source: Default + std::fmt::Debug + Send + Sync {
     async fn get_releases(&self, core: &Core) -> Result<Vec<Release>, errors::Error>;
     async fn get_binary<W: io::Write + Send>(
         &self,
@@ -64,6 +64,12 @@ impl UpdateState {
             temporary_application: self.temporary_application.clone(),
             phase,
         }
+    }
+}
+
+impl std::fmt::Display for UpdateState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.phase)
     }
 }
 


### PR DESCRIPTION
This PR adds support for using OpenTelemetry tracing to assist us in understanding the cause of errors in Git-Tool. I've attempted to avoid the vast majority of situations where we might capture PII (and so the captured telemetry should be entirely devoid of sensitive data) but just to make absolutely certain, I've disabled all reporting by default and you'll need to explicitly opt into reporting it if you'd like to do so (that includes crash dumps reported to Sentry).

If you are running into a problem and wish to report it without enabling telemetry in general, you can now use a `--trace` command line argument to turn on tracing for a single execution (it'll also print out the trace ID to make submitting a bug report easier).