### PR TITLE
feat: Add support for checking whether a repository exists before creating it

### DIFF
--- a/docs/commands/repos.md
+++ b/docs/commands/repos.md
@@ -83,6 +83,7 @@ helping you quickly figure out where your repo should be created.
 
 #### Options
  - `-R`/`--no-create-remote` <Badge text="v2.1+"/> will disable the [creation of a remote repository](../config/features.md#create-remote).
+ - `-E`/`--no-check-exists` <Badge text="v3.3+"/> will disable [checking if the repository already exists](../config/features.md#check-exists).
  - `-o`/`--open` <Badge text="v2.1+"/> will open this repository in your default application once it has been created. You can make this behaviour the default with the [`open_new_repo_in_default_app`](../config/features.md#open-new-repo-in-default-app) feature flag.
 
 #### Example

--- a/docs/config/features.md
+++ b/docs/config/features.md
@@ -40,6 +40,23 @@ you can disable this feature flag.
 Use `gt config feature create_remote_private false` to turn this flag off directly from your command line.
 :::
 
+## `check_exists` <Badge text="v3.3+"/>
+  - **Default** `true`
+  
+The [`gt new`](../commands/new.md) command is responsible for creating repositories which do not exist yet.
+Unfortunately, sometimes people forget that they've already created one with the same name and this can lead
+to unexpected conflicts. To help avoid this, Git-Tool can check whether a repository already exists on a
+supported remote service before attempting to create a new one.
+
+::: tip
+Use `gt config feature check_exists false` to turn this flag off directly from your command line.
+:::
+
+::: warning
+This feature is not supported for all services. For a service to support this feature it must include
+a supported [`api`](./services.md#api) field in its configuration.
+:::
+
 ## `open_new_repo_in_default_app` <Badge text="v2.1.1+"/>
  - **Default** `false`
 

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -131,7 +131,7 @@ mod tests {
             MockResult::Return(Ok("test_token".into()))
         });
 
-        crate::online::service::github::mocks::repo_created("test");
+        crate::online::service::github::mocks::get_repo_not_exists("test/new-repo-partial");
 
         let core = Core::builder().with_config(&cfg).build();
 
@@ -162,7 +162,7 @@ mod tests {
             MockResult::Return(Ok("test_token".into()))
         });
 
-        crate::online::service::github::mocks::repo_created("test");
+        crate::online::service::github::mocks::get_repo_not_exists("test/new-repo-full");
 
         let core = Core::builder().with_config(&cfg).build();
 

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -33,6 +33,12 @@ impl Command for NewCommand {
                     .short('R')
                     .help("prevent the creation of a remote repository (on supported services)"),
             )
+            .arg(
+                Arg::new("no-check-exists")
+                    .long("no-check-exists")
+                    .short('E')
+                    .help("don't check whether the repository already exists on the remote service before creating a new local repository"),
+            )
     }
 }
 
@@ -53,6 +59,9 @@ impl CommandRunnable for NewCommand {
         }
 
         let tasks = sequence![
+            EnsureNoRemote {
+                enabled: !matches.is_present("no-check-exists")
+            },
             GitInit {},
             GitRemote { name: "origin" },
             GitCheckout { branch: "main" },

--- a/src/core/features.rs
+++ b/src/core/features.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 
 pub const CREATE_REMOTE: &str = "create_remote";
 pub const CREATE_REMOTE_PRIVATE: &str = "create_remote_private";
+pub const CHECK_EXISTS: &str = "check_exists";
 
 pub const OPEN_NEW_REPO: &str = "open_new_repo_in_default_app";
 pub const ALWAYS_OPEN_BEST_MATCH: &str = "always_open_best_match";
@@ -14,6 +15,7 @@ lazy_static! {
     pub static ref ALL: Vec<&'static str> = vec![
         CREATE_REMOTE,
         CREATE_REMOTE_PRIVATE,
+        CHECK_EXISTS,
         OPEN_NEW_REPO,
         ALWAYS_OPEN_BEST_MATCH,
         TELEMETRY,
@@ -68,6 +70,7 @@ impl FeaturesBuilder {
             .with(CREATE_REMOTE_PRIVATE, true)
             .with(TELEMETRY, false)
             .with(CHECK_FOR_UPDATES, true)
+            .with(CHECK_EXISTS, true)
     }
 
     pub fn with_features(self, features: &Features) -> Self {

--- a/src/online/service/github.rs
+++ b/src/online/service/github.rs
@@ -425,20 +425,68 @@ pub mod mocks {
     }
 
     pub fn get_repo_exists(repo: &str) {
-        super::HttpClient::mock(vec![super::HttpClient::route(
-            "GET",
-            format!("https://api.github.com/repos/{}", repo).as_str(),
-            200,
-            r#"{ "id": 1234 }"#,
-        )]);
+        super::HttpClient::mock(vec![
+            super::HttpClient::route(
+                "GET",
+                "https://api.github.com/user",
+                200,
+                r#"{ "login": "test" }"#,
+            ),
+            super::HttpClient::route(
+                "POST",
+                "https://api.github.com/user/repos",
+                201,
+                r#"{ "id": 1234 }"#,
+            ),
+            super::HttpClient::route(
+                "POST",
+                format!(
+                    "https://api.github.com/orgs/{}/repos",
+                    repo.split('/').next().unwrap()
+                )
+                .as_str(),
+                201,
+                r#"{ "id": 1234 }"#,
+            ),
+            super::HttpClient::route(
+                "GET",
+                format!("https://api.github.com/repos/{}", repo).as_str(),
+                200,
+                r#"{ "id": 1234 }"#,
+            ),
+        ]);
     }
 
     pub fn get_repo_not_exists(repo: &str) {
-        super::HttpClient::mock(vec![super::HttpClient::route(
-            "GET",
-            format!("https://api.github.com/repos/{}", repo).as_str(),
-            404,
-            r#"{"message":"Not Found","documentation_url":"https://developer.github.com/v3/repos/#get"}"#,
-        )]);
+        super::HttpClient::mock(vec![
+            super::HttpClient::route(
+                "GET",
+                "https://api.github.com/user",
+                200,
+                r#"{ "login": "test" }"#,
+            ),
+            super::HttpClient::route(
+                "POST",
+                "https://api.github.com/user/repos",
+                201,
+                r#"{ "id": 1234 }"#,
+            ),
+            super::HttpClient::route(
+                "POST",
+                format!(
+                    "https://api.github.com/orgs/{}/repos",
+                    repo.split('/').next().unwrap()
+                )
+                .as_str(),
+                201,
+                r#"{ "id": 1234 }"#,
+            ),
+            super::HttpClient::route(
+                "GET",
+                format!("https://api.github.com/repos/{}", repo).as_str(),
+                404,
+                r#"{"message":"Not Found","documentation_url":"https://developer.github.com/v3/repos/#get"}"#,
+            ),
+        ]);
     }
 }

--- a/src/online/service/mod.rs
+++ b/src/online/service/mod.rs
@@ -8,6 +8,7 @@ pub mod github;
 pub trait OnlineService: Send + Sync {
     fn handles(&self, service: &Service) -> bool;
     async fn test(&self, core: &Core, service: &Service) -> Result<(), Error>;
+    async fn is_created(&self, core: &Core, service: &Service, repo: &Repo) -> Result<bool, Error>;
     async fn ensure_created(
         &self,
         core: &Core,

--- a/src/tasks/ensure_no_remote.rs
+++ b/src/tasks/ensure_no_remote.rs
@@ -1,0 +1,138 @@
+use super::*;
+
+pub struct EnsureNoRemote {
+    pub enabled: bool,
+}
+
+impl Default for EnsureNoRemote {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
+#[async_trait::async_trait]
+impl Task for EnsureNoRemote {
+    #[cfg(feature = "auth")]
+    #[tracing::instrument(name = "task:ensure_no_remote(repo)", err, skip(self, core))]
+    async fn apply_repo(&self, core: &Core, repo: &core::Repo) -> Result<(), core::Error> {
+        if !self.enabled {
+            return Ok(());
+        }
+
+        if !core
+            .config()
+            .get_features()
+            .has(core::features::CHECK_EXISTS)
+        {
+            return Ok(());
+        }
+
+        let service = core.config().get_service(&repo.service).ok_or_else(|| crate::errors::user(
+                &format!("Could not find a service entry in your config file for {}", repo.service), 
+                &format!("Ensure that your git-tool configuration has a service entry for this service, or add it with `git-tool config add service/{}`", repo.service)))?;
+
+        if let Some(online_service) = crate::online::services()
+            .iter()
+            .find(|s| s.handles(service))
+        {
+            if online_service.is_created(core, service, repo).await? {
+                return Err(crate::errors::user(
+                    &format!("The remote repository {} already exists", repo.get_full_name()),
+                    &format!("If you want to open this repository, you can clone it locally with `git-tool open {}:{}`", &repo.service, repo.get_full_name()),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg(not(feature = "auth"))]
+    #[tracing::instrument(name = "task:create_remote(repo)", err, skip(self, _core))]
+    async fn apply_repo(&self, _core: &Core, _repo: &core::Repo) -> Result<(), core::Error> {
+        Ok(())
+    }
+
+    #[tracing::instrument(name = "task:create_remote(scratchpad)", err, skip(self, _core))]
+    async fn apply_scratchpad(
+        &self,
+        _core: &Core,
+        _scratch: &core::Scratchpad,
+    ) -> Result<(), core::Error> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{Config, KeyChain, Target};
+    use mocktopus::mocking::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    #[cfg(feature = "auth")]
+    async fn test_repo_exists() {
+        let temp = tempdir().unwrap();
+        let repo = core::Repo::new(
+            "gh:sierrasoftworks/test-git-remote",
+            temp.path().join("repo"),
+        );
+
+        KeyChain::get_token.mock_safe(|_, token| {
+            assert_eq!(token, "gh", "the correct token should be requested");
+            MockResult::Return(Ok("test_token".into()))
+        });
+
+        crate::online::service::github::mocks::get_repo_exists("sierrasoftworks/test-git-remote");
+
+        let core = core::Core::builder()
+            .with_config(&Config::for_dev_directory(temp.path()))
+            .build();
+        EnsureNoRemote { enabled: true }
+            .apply_repo(&core, &repo)
+            .await
+            .expect_err("Expected an error to be returned");
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "auth")]
+    async fn test_repo_not_exists() {
+        let temp = tempdir().unwrap();
+        let repo = core::Repo::new(
+            "gh:sierrasoftworks/test-git-remote",
+            temp.path().join("repo"),
+        );
+
+        KeyChain::get_token.mock_safe(|_, token| {
+            assert_eq!(token, "gh", "the correct token should be requested");
+            MockResult::Return(Ok("test_token".into()))
+        });
+
+        crate::online::service::github::mocks::get_repo_not_exists(
+            "sierrasoftworks/test-git-remote",
+        );
+
+        let core = core::Core::builder()
+            .with_config(&Config::for_dev_directory(temp.path()))
+            .build();
+        EnsureNoRemote { enabled: true }
+            .apply_repo(&core, &repo)
+            .await
+            .expect("Expected no error to be returned");
+    }
+
+    #[tokio::test]
+    async fn test_scratch() {
+        let temp = tempdir().unwrap();
+        let scratch = core::Scratchpad::new("2019w15", temp.path().join("scratch"));
+
+        let core = core::Core::builder()
+            .with_config(&Config::for_dev_directory(temp.path()))
+            .build();
+
+        let task = EnsureNoRemote { enabled: true };
+
+        task.apply_scratchpad(&core, &scratch).await.unwrap();
+        assert!(!scratch.exists());
+    }
+}

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -19,6 +19,7 @@ macro_rules! sequence {
 }
 
 mod create_remote;
+mod ensure_no_remote;
 mod git_add;
 mod git_checkout;
 mod git_clone;
@@ -30,6 +31,7 @@ mod new_folder;
 mod write_file;
 
 pub use create_remote::CreateRemote;
+pub use ensure_no_remote::EnsureNoRemote;
 pub use git_add::GitAdd;
 pub use git_checkout::GitCheckout;
 pub use git_clone::GitClone;


### PR DESCRIPTION
This PR adds a new `check_exists` feature flag which, when enabled and attempting to create a repository on a supported service, will first check whether the service has an existing repo with the same name.