### PR TITLE
feat: Add support for loading Git-Tool's config from a default config path

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -134,11 +134,7 @@ impl CommandRunnable for ConfigCommand {
 
                         match cfg.get_config_file() {
                             Some(path) => {
-                                tokio::fs::write(&path, cfg.to_string()?).await.map_err(|err| errors::user_with_internal(
-                                    &format!("Could not write your updated config to the config file '{}' due to an OS-level error.", path.display()),
-                                    "Make sure that Git-Tool has permission to write to your config file and then try again.",
-                                    err
-                                ))?;
+                                cfg.save(&path).await?;
                             }
                             None => {
                                 writeln!(output, "{}", cfg.to_string()?)?;
@@ -155,11 +151,7 @@ impl CommandRunnable for ConfigCommand {
 
                             match cfg.get_config_file() {
                                 Some(path) => {
-                                    tokio::fs::write(&path, cfg.to_string()?).await.map_err(|err| errors::user_with_internal(
-                                        &format!("Could not write your updated config to the config file '{}' due to an OS-level error.", path.display()),
-                                        "Make sure that Git-Tool has permission to write to your config file and then try again.",
-                                        err
-                                    ))?;
+                                    cfg.save(&path).await?;
                                 }
                                 None => {
                                     writeln!(output, "{}", cfg.to_string()?)?;
@@ -189,7 +181,7 @@ impl CommandRunnable for ConfigCommand {
 
                         match cfg.get_config_file() {
                             Some(path) => {
-                                tokio::fs::write(&path, cfg.to_string()?).await?;
+                                cfg.save(&path).await?;
                             }
                             None => {
                                 writeln!(output, "{}", cfg.to_string()?)?;

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -130,11 +130,7 @@ mod tests {
         );
 
         // Ensure that the config file is created
-        std::fs::write(
-            temp.path().join("config.yml"),
-            serde_yaml::to_string(&cfg).unwrap(),
-        )
-        .unwrap();
+        cfg.save(temp.path().join("config.yml")).await.unwrap();
 
         let cmd = DoctorCommand {};
         match cmd.run(&core, &args).await {

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -168,7 +168,7 @@ impl SetupCommand {
             match ProjectDirs::from("com", "SierraSoftworks", "Git-Tool") {
                 Some(dirs) => {
                     let mut path = dirs.config_dir().to_path_buf();
-                    path.push("git-tool.yml");
+                    path.push("config.yml");
                     Some(path)
                 }
                 None => None,

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -90,11 +90,7 @@ impl CommandRunnable for SetupCommand {
             .with_dev_directory(&dev_directory)
             .with_feature_flag("telemetry", enable_telemetry);
 
-        tokio::fs::write(&config_path, new_config.to_string()?).await.map_err(|err| errors::user_with_internal(
-            &format!("We couldn't write the new config file to '{}' due to a system error.", config_path.display()),
-            "For access denied errors, make sure you have write permission to the location containing your config file. If you run into trouble, please create a GitHub issue and we will try to help.",
-            err
-        ))?;
+        new_config.save(&config_path).await?;
 
         writeln!(core.output(),"\nSuccess! We've written your config to disk, now we need to configure your system to use it.")?;
         self.prompt_setup_shell(core, &config_path, &mut prompter)?;
@@ -165,14 +161,8 @@ impl SetupCommand {
 
     fn prompt_config_path(&self, core: &Core, prompter: &mut Prompter) -> Result<PathBuf, Error> {
         let default_path = core.config().get_config_file().or_else(|| {
-            match ProjectDirs::from("com", "SierraSoftworks", "Git-Tool") {
-                Some(dirs) => {
-                    let mut path = dirs.config_dir().to_path_buf();
-                    path.push("config.yml");
-                    Some(path)
-                }
-                None => None,
-            }
+            ProjectDirs::from("com", "SierraSoftworks", "Git-Tool")
+                .map(|dirs| dirs.config_dir().join("config.yml"))
         });
 
         let config_path = prompter.prompt(

--- a/src/core/builder.rs
+++ b/src/core/builder.rs
@@ -33,4 +33,8 @@ impl CoreBuilder {
 
         Ok(self.with_config(&cfg))
     }
+
+    pub fn with_config_file_or_default<P: Into<PathBuf>>(self, cfg_file: P) -> Self {
+        self.with_config(&Config::from_file_or_default(&cfg_file.into()))
+    }
 }

--- a/src/core/builder.rs
+++ b/src/core/builder.rs
@@ -1,5 +1,5 @@
 use super::{Config, Core, Error, HttpClient, KeyChain, Launcher, Resolver};
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 pub struct CoreBuilder {
     pub(super) config: Arc<Config>,
@@ -28,8 +28,8 @@ impl CoreBuilder {
         Self { config: c }
     }
 
-    pub fn with_config_file(self, cfg_file: &str) -> Result<Self, Error> {
-        let cfg = Config::from_file(&std::path::PathBuf::from(cfg_file))?;
+    pub fn with_config_file<P: Into<PathBuf>>(self, cfg_file: P) -> Result<Self, Error> {
+        let cfg = Config::from_file(&cfg_file.into())?;
 
         Ok(self.with_config(&cfg))
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,7 +213,8 @@ async fn run(
         directories_next::ProjectDirs::from("com", "SierraSoftworks", "Git-Tool")
     {
         debug!("Loading configuration from default config file...");
-        core_builder = core_builder.with_config_file(dirs.config_dir().join("config.yml"))?;
+        core_builder =
+            core_builder.with_config_file_or_default(dirs.config_dir().join("config.yml"));
     } else {
         warn!("No configuration file was specified and we were unable to determine the default configuration file location.");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,13 @@ async fn run(
     if let Some(cfg_file) = matches.value_of("config") {
         debug!("Loading configuration file...");
         core_builder = core_builder.with_config_file(cfg_file)?;
+    } else if let Some(dirs) =
+        directories_next::ProjectDirs::from("com", "SierraSoftworks", "Git-Tool")
+    {
+        debug!("Loading configuration from default config file...");
+        core_builder = core_builder.with_config_file(dirs.config_dir().join("config.yml"))?;
+    } else {
+        warn!("No configuration file was specified and we were unable to determine the default configuration file location.");
     }
 
     let core = core_builder.build();


### PR DESCRIPTION
This refactor is designed to greatly simplify first-time setup by chosing some reasonable default paths and allowing you to use Git-Tool without needing to create a custom config file and export the `GITTOOL_CONFIG` environment variable.