### PR TITLE
test: Remove the need for pre-emptive git configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,8 +140,6 @@ jobs:
 
       - name: git config
         run: |
-          git config --global user.name "Test User"
-          git config --global user.email "test@example.com"
           git config --global init.defaultBranch "main"
 
       - name: cargo build

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -364,6 +364,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(feature = "pure-tests", ignore)]
     async fn run_list() {
         let cfg = Config::from_str("directory: /dev").unwrap();
         let console = crate::console::mock();

--- a/src/git/commit.rs
+++ b/src/git/commit.rs
@@ -34,6 +34,14 @@ mod tests {
 
         git_init(temp.path()).await.unwrap();
 
+        // Configure Git's user to avoid requiring this to be set in the environment
+        git_config_set(temp.path(), "user.name", "Test User")
+            .await
+            .unwrap();
+        git_config_set(temp.path(), "user.email", "user@example.com")
+            .await
+            .unwrap();
+
         std::fs::write(temp.path().join("test.txt"), "testing").unwrap();
         assert!(
             temp.path().join("test.txt").exists(),

--- a/src/git/config.rs
+++ b/src/git/config.rs
@@ -1,0 +1,23 @@
+use std::path;
+
+use tokio::process::Command;
+
+use crate::{errors, git::git_cmd};
+
+pub async fn git_config_set(
+    repo: &path::Path,
+    key: &str,
+    value: &str,
+) -> Result<(), errors::Error> {
+    info!("Running `git config` to set a configuration value");
+    git_cmd(
+        Command::new("git")
+            .current_dir(repo)
+            .arg("config")
+            .arg(key)
+            .arg(value),
+    )
+    .await?;
+
+    Ok(())
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -10,6 +10,8 @@ mod remote;
 mod switch;
 
 #[cfg(test)]
+mod config;
+#[cfg(test)]
 mod refs;
 
 pub use add::git_add;
@@ -25,5 +27,7 @@ pub use init::git_init;
 pub use remote::{git_remote_add, git_remote_list, git_remote_set_url};
 pub use switch::git_switch;
 
+#[cfg(test)]
+pub use config::git_config_set;
 #[cfg(test)]
 pub use refs::{git_rev_parse, git_update_ref};

--- a/src/tasks/git_clone.rs
+++ b/src/tasks/git_clone.rs
@@ -17,7 +17,15 @@ impl Task for GitClone {
 
         let url = service.get_git_url(repo)?;
 
-        git::git_clone(&repo.get_path(), &url).await
+        git::git_clone(&repo.get_path(), &url).await?;
+
+        #[cfg(test)]
+        {
+            git::git_config_set(&repo.get_path(), "user.name", "Example User").await?;
+            git::git_config_set(&repo.get_path(), "user.email", "user@example.com").await?;
+        }
+
+        Ok(())
     }
 
     #[tracing::instrument(name = "task:git_clone(scratchpad)", err, skip(self, _core))]

--- a/src/tasks/git_init.rs
+++ b/src/tasks/git_init.rs
@@ -7,7 +7,15 @@ pub struct GitInit {}
 impl Task for GitInit {
     #[tracing::instrument(name = "task:git_init(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &core::Repo) -> Result<(), core::Error> {
-        git::git_init(&repo.get_path()).await
+        git::git_init(&repo.get_path()).await?;
+
+        #[cfg(test)]
+        {
+            git::git_config_set(&repo.get_path(), "user.name", "Example User").await?;
+            git::git_config_set(&repo.get_path(), "user.email", "user@example.com").await?;
+        }
+
+        Ok(())
     }
 
     #[tracing::instrument(name = "task:git_init(scratchpad)", err, skip(self, _core))]


### PR DESCRIPTION
This PR adds native support to the test suite for configuring the `user.name` and `user.email` Git options on a per-repository basis (when generating and/or cloning temporary repositories for testing purposes). This removes the need to pre-configure the test environment and should resolve some of the failures we're seeing when running the Nix test suite in an uninitialized build environment.