### PR TITLE
fix: Resolve OpenTelemetry status reporting

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,6 +1,5 @@
 name: "Nix"
 on:
-  pull_request:
   push:
 jobs:
   flake:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,10 @@ jobs:
       - name: Generate Package Version
         id: version
         shell: pwsh
-        run: Add-Content -Path $env:GITHUB_ENV -Value "version=$('${{ github.event.release.tag_name }}'.substring(1))"
+        run: |
+          $VERSION="$('${{ github.event.release.tag_name }}'.substring(1))"
+          Add-Content -Path $env:GITHUB_ENV -Value "version=$VERSION"
+          Write-Host $VERSION
 
       - name: Set Package Version
         uses: ciiiii/toml-editor@1.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "git-tool"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-tool"
-version = "3.5.0"
+version = "3.6.0"
 authors = ["Benjamin Pannell <benjamin@pannell.dev>", "Aideen Fay <me@aideen.dev>"]
 edition = "2018"
 

--- a/src/git/cmd.rs
+++ b/src/git/cmd.rs
@@ -4,7 +4,7 @@ use std::process::Stdio;
 use tokio::process::Command;
 use tracing::{field, Span};
 
-#[tracing::instrument(err, skip(cmd), fields(otel.kind = ?SpanKind::Client, command=?cmd, otel.status = "ok", status_code = field::Empty))]
+#[tracing::instrument(err, skip(cmd), fields(otel.kind = ?SpanKind::Client, command=?cmd, otel.status_code = 0, status_code = field::Empty))]
 pub async fn git_cmd(cmd: &mut Command) -> Result<String, errors::Error> {
     // NOTE: We disable logging to stdout to avoid breaking the test output
     #[cfg(test)]
@@ -28,7 +28,7 @@ pub async fn git_cmd(cmd: &mut Command) -> Result<String, errors::Error> {
             Some(code) => {
                 Span::current()
                     .record("status_code", &code)
-                    .record("otel.status", "error");
+                    .record("otel.status_code", &2_u32);
                 Err(errors::user_with_cause(
                     "Git exited with a failure status code.",
                     "Please check the output printed by Git to determine why the command failed and take appropriate action.",
@@ -37,7 +37,7 @@ pub async fn git_cmd(cmd: &mut Command) -> Result<String, errors::Error> {
             None => {
                 Span::current()
                     .record("status_code", &1_i32)
-                    .record("otel.status", "error");
+                    .record("otel.status_code", &2_u32);
                 Err(errors::system_with_internal(
                     "Git exited prematurely because it received an unexpected signal.",
                     "Please check the output printed by Git to determine why the command failed and take appropriate action.",

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,18 @@ async fn host(
         }
         Err(error) => {
             error.print().unwrap_or_default();
+
+            tracing::Span::current()
+                .record(
+                    "otel.name",
+                    if error.kind() == clap::error::ErrorKind::DisplayVersion {
+                        "gt --version"
+                    } else {
+                        "gt --help"
+                    },
+                )
+                .record("exit_code", &2_u32);
+
             return Ok(2);
         }
     };


### PR DESCRIPTION
This PR resolves the way in which we report the status of OpenTelemetry spans for web requests, ensuring that we don't inadvertently record "error" spans for successful requests.