### PR TITLE
feat: Add authentication instructions when running gt auth

### DIFF
--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -60,7 +60,7 @@ impl CommandRunnable for AuthCommand {
                         if let Some(online_service) = crate::online::service::services()
                             .iter()
                             .cloned()
-                            .find(|s| s.handles(&svc))
+                            .find(|s| s.handles(svc))
                         {
                             writeln!(core.output(), "{}", online_service.auth_instructions())?;
                         }

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -57,6 +57,14 @@ impl CommandRunnable for AuthCommand {
                 let token = match matches.get_one::<String>("token") {
                     Some(token) => token.to_string(),
                     None => {
+                        if let Some(online_service) = crate::online::service::services()
+                            .iter()
+                            .cloned()
+                            .find(|s| s.handles(&svc))
+                        {
+                            writeln!(core.output(), "{}", online_service.auth_instructions())?;
+                        }
+
                         writeln!(core.output(), "Access Token: ")?;
                         rpassword::read_password().map_err(|e| errors::user_with_internal(
                         "Could not read the access token that you entered.",

--- a/src/online/service/github.rs
+++ b/src/online/service/github.rs
@@ -19,6 +19,10 @@ impl OnlineService for GitHubService {
             .unwrap_or(false)
     }
 
+    fn auth_instructions(&self) -> String {
+        "Create a new Personal Access Token with the 'repo' scope at https://github.com/settings/tokens/new?scopes=repo".into()
+    }
+
     async fn test(&self, core: &Core, service: &Service) -> Result<(), Error> {
         self.get_user_login(core, service).await?;
         Ok(())

--- a/src/online/service/mod.rs
+++ b/src/online/service/mod.rs
@@ -7,6 +7,7 @@ pub mod github;
 #[async_trait]
 pub trait OnlineService: Send + Sync {
     fn handles(&self, service: &Service) -> bool;
+    fn auth_instructions(&self) -> String;
     async fn test(&self, core: &Core, service: &Service) -> Result<(), Error>;
     async fn is_created(&self, core: &Core, service: &Service, repo: &Repo) -> Result<bool, Error>;
     async fn ensure_created(


### PR DESCRIPTION
This PR adds a message instructing the user on how to authenticate when running `gt auth <svc>`, simplifying initial bootstrapping.