### PR TITLE
refactor: Switch to dynamically discovering commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,6 +879,7 @@ dependencies = [
  "gtmpl",
  "http",
  "human-errors",
+ "inventory",
  "itertools 0.12.0",
  "keyring",
  "lazy_static",
@@ -1158,6 +1159,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "inventory"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0508c56cfe9bfd5dfeb0c22ab9a6abfda2f27bdca422132e494266351ed8d83c"
 
 [[package]]
 name = "io-lifetimes"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ futures = "0.3"
 gtmpl = "0.7"
 human-errors = "0.1.3"
 http = "0.2"
+inventory = "0.3.13"
 itertools = "0.12"
 keyring = { version = "2.1", optional = true }
 lazy_static = "1.4"

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -1,8 +1,11 @@
 use super::*;
 
-pub struct AppsCommand {}
+pub struct AppsCommand;
 
-impl Command for AppsCommand {
+crate::command!(AppsCommand);
+
+#[async_trait]
+impl CommandRunnable for AppsCommand {
     fn name(&self) -> String {
         String::from("apps")
     }
@@ -12,10 +15,7 @@ impl Command for AppsCommand {
             .about("list applications which can be run through Git-Tool")
             .long_about("Gets the list of applications that you have added to your configuration file. These applications can be run through the `open` and `scratch` commands.")
     }
-}
 
-#[async_trait]
-impl CommandRunnable for AppsCommand {
     #[tracing::instrument(name = "gt apps", err, skip(self, core, _matches))]
     async fn run(
         &self,

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -1,9 +1,12 @@
 use super::*;
 use clap::Arg;
 
-pub struct AuthCommand {}
+pub struct AuthCommand;
 
-impl Command for AuthCommand {
+crate::command!(AuthCommand);
+
+#[async_trait]
+impl CommandRunnable for AuthCommand {
     fn name(&self) -> String {
         String::from("auth")
     }
@@ -26,10 +29,7 @@ impl Command for AuthCommand {
                 .help("specifies the token to be set (don't use this unless you have to)")
                 .action(clap::ArgAction::Set))
     }
-}
 
-#[async_trait]
-impl CommandRunnable for AuthCommand {
     #[tracing::instrument(name = "gt auth", err, skip(self, core, matches))]
     async fn run(
         &self,

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -4,9 +4,12 @@ use crate::core::Target;
 use crate::tasks::*;
 use clap::{Arg, ArgMatches};
 
-pub struct CloneCommand {}
+pub struct CloneCommand;
 
-impl Command for CloneCommand {
+crate::command!(CloneCommand);
+
+#[async_trait]
+impl CommandRunnable for CloneCommand {
     fn name(&self) -> String {
         String::from("clone")
     }
@@ -21,10 +24,7 @@ impl Command for CloneCommand {
                     .required(true)
                     .index(1))
     }
-}
 
-#[async_trait]
-impl CommandRunnable for CloneCommand {
     #[tracing::instrument(name = "gt clone", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         let repo_name = matches.get_one::<String>("repo").ok_or_else(|| errors::user(

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,14 +1,17 @@
 use crate::core::features;
 
 use super::async_trait;
-use super::Command;
+use super::CommandRunnable;
 use super::*;
 use clap::{Arg, ArgMatches};
 use online::registry::Registry;
 
-pub struct ConfigCommand {}
+pub struct ConfigCommand;
 
-impl Command for ConfigCommand {
+crate::command!(ConfigCommand);
+
+#[async_trait]
+impl CommandRunnable for ConfigCommand {
     fn name(&self) -> String {
         String::from("config")
     }
@@ -84,10 +87,7 @@ impl Command for ConfigCommand {
                     .help("configure the scratchpads path instead of the repositories path")
                     .action(clap::ArgAction::SetTrue)))
     }
-}
 
-#[async_trait]
-impl CommandRunnable for ConfigCommand {
     #[tracing::instrument(name = "gt config", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         match matches.subcommand() {

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,8 +1,10 @@
 use super::*;
 
-pub struct DoctorCommand {}
+pub struct DoctorCommand;
+crate::command!(DoctorCommand);
 
-impl Command for DoctorCommand {
+#[async_trait]
+impl CommandRunnable for DoctorCommand {
     fn name(&self) -> String {
         String::from("doctor")
     }
@@ -13,10 +15,7 @@ impl Command for DoctorCommand {
             .about("checks that your environment is configured correctly for Git-Tool")
             .long_about("Runs a series of checks to ensure that the environment is ready to run the application")
     }
-}
 
-#[async_trait]
-impl CommandRunnable for DoctorCommand {
     #[tracing::instrument(name = "gt doctor", err, skip(self, core, _matches))]
     async fn run(
         &self,

--- a/src/commands/fix.rs
+++ b/src/commands/fix.rs
@@ -3,9 +3,11 @@ use super::*;
 use crate::{search, tasks::*};
 use clap::{Arg, ArgMatches};
 
-pub struct FixCommand {}
+pub struct FixCommand;
+crate::command!(FixCommand);
 
-impl Command for FixCommand {
+#[async_trait]
+impl CommandRunnable for FixCommand {
     fn name(&self) -> String {
         String::from("fix")
     }
@@ -29,10 +31,7 @@ impl Command for FixCommand {
                 .help("prevent the creation of a remote repository (on supported services)")
                 .action(clap::ArgAction::SetTrue))
     }
-}
 
-#[async_trait]
-impl CommandRunnable for FixCommand {
     #[tracing::instrument(name = "gt fix", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         let tasks = sequence![

--- a/src/commands/ignore.rs
+++ b/src/commands/ignore.rs
@@ -1,12 +1,14 @@
 use super::async_trait;
 use super::online::gitignore;
-use super::Command;
+use super::CommandRunnable;
 use super::*;
 use clap::{value_parser, Arg, ArgMatches};
 
-pub struct IgnoreCommand {}
+pub struct IgnoreCommand;
+crate::command!(IgnoreCommand);
 
-impl Command for IgnoreCommand {
+#[async_trait]
+impl CommandRunnable for IgnoreCommand {
     fn name(&self) -> String {
         String::from("ignore")
     }
@@ -29,10 +31,7 @@ impl Command for IgnoreCommand {
                     .action(clap::ArgAction::Append)
                     .index(1))
     }
-}
 
-#[async_trait]
-impl CommandRunnable for IgnoreCommand {
     #[tracing::instrument(name = "gt ignore", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         match matches.get_many::<String>("language") {

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -3,9 +3,11 @@ use super::core::Target;
 use super::*;
 use clap::{Arg, ArgMatches};
 
-pub struct InfoCommand {}
+pub struct InfoCommand;
+crate::command!(InfoCommand);
 
-impl Command for InfoCommand {
+#[async_trait]
+impl CommandRunnable for InfoCommand {
     fn name(&self) -> String {
         String::from("info")
     }
@@ -20,10 +22,7 @@ impl Command for InfoCommand {
                     .help("The name of the repository to get information about.")
                     .index(1))
     }
-}
 
-#[async_trait]
-impl CommandRunnable for InfoCommand {
     #[tracing::instrument(name = "gt info", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         let mut output = core.output();
@@ -75,6 +74,8 @@ impl CommandRunnable for InfoCommand {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use mockall::predicate::eq;
 
     use super::*;

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -3,9 +3,11 @@ use crate::core::Target;
 use crate::search;
 use clap::Arg;
 
-pub struct ListCommand {}
+pub struct ListCommand;
+crate::command!(ListCommand);
 
-impl Command for ListCommand {
+#[async_trait]
+impl CommandRunnable for ListCommand {
     fn name(&self) -> String {
         String::from("list")
     }
@@ -29,10 +31,7 @@ impl Command for ListCommand {
                 .conflicts_with("quiet")
                 .action(clap::ArgAction::SetTrue))
     }
-}
 
-#[async_trait]
-impl CommandRunnable for ListCommand {
     #[tracing::instrument(name = "gt list", err, skip(self, core, matches))]
     async fn run(
         &self,
@@ -122,6 +121,7 @@ mod tests {
     use crate::console::MockConsoleProvider;
     use crate::test::get_dev_dir;
     use std::path::PathBuf;
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn run_normal() {

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -3,9 +3,11 @@ use super::*;
 use crate::{core::features, tasks::*};
 use clap::{Arg, ArgMatches};
 
-pub struct NewCommand {}
+pub struct NewCommand;
+crate::command!(NewCommand);
 
-impl Command for NewCommand {
+#[async_trait]
+impl CommandRunnable for NewCommand {
     fn name(&self) -> String {
         "new".into()
     }
@@ -43,10 +45,7 @@ impl Command for NewCommand {
                     .action(clap::ArgAction::SetTrue),
             )
     }
-}
 
-#[async_trait]
-impl CommandRunnable for NewCommand {
     #[tracing::instrument(name = "gt new", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         let repo = match matches.get_one::<String>("repo") {

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -1,4 +1,4 @@
-use super::Command;
+use super::CommandRunnable;
 use super::*;
 use crate::core::features;
 use crate::tasks::*;
@@ -6,9 +6,11 @@ use crate::update::{GitHubSource, Release, ReleaseVariant};
 use crate::{core::Target, update::UpdateManager};
 use clap::{Arg, ArgMatches};
 
-pub struct OpenCommand {}
+pub struct OpenCommand;
+crate::command!(OpenCommand);
 
-impl Command for OpenCommand {
+#[async_trait]
+impl CommandRunnable for OpenCommand {
     fn name(&self) -> String {
         String::from("open")
     }
@@ -38,10 +40,7 @@ New applications can be configured either by making changes to your configuratio
                     .help("prevent the creation of a remote repository (on supported services)")
                     .action(clap::ArgAction::SetTrue))
     }
-}
 
-#[async_trait]
-impl CommandRunnable for OpenCommand {
     #[tracing::instrument(name = "gt open", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         if core.config().get_config_file().is_none() {

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -5,9 +5,11 @@ use crate::git;
 use clap::Arg;
 use itertools::Itertools;
 
-pub struct PruneCommand {}
+pub struct PruneCommand;
+crate::command!(PruneCommand);
 
-impl Command for PruneCommand {
+#[async_trait]
+impl CommandRunnable for PruneCommand {
     fn name(&self) -> String {
         String::from("prune")
     }
@@ -32,10 +34,7 @@ impl Command for PruneCommand {
                 .help("The branch patterns which should be pruned")
                 .action(clap::ArgAction::Append))
     }
-}
 
-#[async_trait]
-impl CommandRunnable for PruneCommand {
     #[tracing::instrument(name = "gt prune", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         let repo = core.resolver().get_current_repo()?;

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -1,11 +1,13 @@
-use super::Command;
+use super::CommandRunnable;
 use super::*;
 use crate::core::Target;
 use clap::{Arg, ArgMatches};
 
-pub struct RemoveCommand {}
+pub struct RemoveCommand;
+crate::command!(RemoveCommand);
 
-impl Command for RemoveCommand {
+#[async_trait]
+impl CommandRunnable for RemoveCommand {
     fn name(&self) -> String {
         String::from("remove")
     }
@@ -21,10 +23,7 @@ impl Command for RemoveCommand {
                     .index(1)
                 .required(true))
     }
-}
 
-#[async_trait]
-impl CommandRunnable for RemoveCommand {
     #[tracing::instrument(name = "gt remove", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         let repo_name = matches.get_one::<String>("repo").ok_or_else(|| {

--- a/src/commands/scratch.rs
+++ b/src/commands/scratch.rs
@@ -1,11 +1,13 @@
 use super::async_trait;
 use super::*;
-use super::{core::Target, tasks, tasks::Task, Command};
+use super::{core::Target, tasks, tasks::Task, CommandRunnable};
 use clap::{Arg, ArgMatches};
 
-pub struct ScratchCommand {}
+pub struct ScratchCommand;
+crate::command!(ScratchCommand);
 
-impl Command for ScratchCommand {
+#[async_trait]
+impl CommandRunnable for ScratchCommand {
     fn name(&self) -> String {
         String::from("scratch")
     }
@@ -26,10 +28,7 @@ impl Command for ScratchCommand {
                     .index(2),
             )
     }
-}
 
-#[async_trait]
-impl CommandRunnable for ScratchCommand {
     #[tracing::instrument(name = "gt scratch", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         let (app, scratchpad) = match helpers::get_launch_app(

--- a/src/commands/services.rs
+++ b/src/commands/services.rs
@@ -1,8 +1,10 @@
 use super::*;
 
-pub struct ServicesCommand {}
+pub struct ServicesCommand;
+crate::command!(ServicesCommand);
 
-impl Command for ServicesCommand {
+#[async_trait]
+impl CommandRunnable for ServicesCommand {
     fn name(&self) -> String {
         String::from("services")
     }
@@ -12,10 +14,7 @@ impl Command for ServicesCommand {
             .about("list services which can be used with Git-Tool")
             .long_about("Gets the list of services that you have added to your configuration file. These services are responsible for hosting your Git repositories.")
     }
-}
 
-#[async_trait]
-impl CommandRunnable for ServicesCommand {
     #[tracing::instrument(name = "gt services", err, skip(self, core, _matches))]
     async fn run(
         &self,
@@ -42,6 +41,7 @@ impl CommandRunnable for ServicesCommand {
 mod tests {
     use super::*;
     use crate::console::MockConsoleProvider;
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn run() {

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -11,9 +11,11 @@ use itertools::Itertools;
 
 use super::*;
 
-pub struct SetupCommand {}
+pub struct SetupCommand;
+crate::command!(SetupCommand);
 
-impl Command for SetupCommand {
+#[async_trait]
+impl CommandRunnable for SetupCommand {
     fn name(&self) -> String {
         String::from("setup")
     }
@@ -28,10 +30,7 @@ impl Command for SetupCommand {
                 .help("Run the setup wizard even if you already have a config file.")
                 .action(clap::ArgAction::SetTrue))
     }
-}
 
-#[async_trait]
-impl CommandRunnable for SetupCommand {
     #[tracing::instrument(name = "gt setup", err, skip(self, core, matches))]
     async fn run(
         &self,

--- a/src/commands/shell_init.rs
+++ b/src/commands/shell_init.rs
@@ -2,9 +2,11 @@ use super::*;
 use crate::completion::get_shells;
 use clap::Arg;
 
-pub struct ShellInitCommand {}
+pub struct ShellInitCommand;
+crate::command!(ShellInitCommand);
 
-impl Command for ShellInitCommand {
+#[async_trait]
+impl CommandRunnable for ShellInitCommand {
     fn name(&self) -> String {
         String::from("shell-init")
     }
@@ -32,10 +34,7 @@ impl Command for ShellInitCommand {
 
         cmd
     }
-}
 
-#[async_trait]
-impl CommandRunnable for ShellInitCommand {
     #[tracing::instrument(name = "gt shell-init", err, skip(self, core, matches))]
     async fn run(
         &self,
@@ -82,6 +81,7 @@ where {
 mod tests {
     use super::*;
     use crate::console::MockConsoleProvider;
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn run() {

--- a/src/commands/switch.rs
+++ b/src/commands/switch.rs
@@ -6,9 +6,11 @@ use crate::tasks::*;
 use clap::Arg;
 use itertools::Itertools;
 
-pub struct SwitchCommand {}
+pub struct SwitchCommand;
+crate::command!(SwitchCommand);
 
-impl Command for SwitchCommand {
+#[async_trait]
+impl CommandRunnable for SwitchCommand {
     fn name(&self) -> String {
         String::from("switch")
     }
@@ -34,10 +36,7 @@ impl Command for SwitchCommand {
                     .action(clap::ArgAction::SetTrue),
             )
     }
-}
 
-#[async_trait]
-impl CommandRunnable for SwitchCommand {
     #[tracing::instrument(name = "gt switch", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
         let repo = core.resolver().get_current_repo()?;

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -2,9 +2,11 @@ use super::*;
 use crate::update::{GitHubSource, Release, ReleaseVariant, UpdateManager};
 use clap::Arg;
 
-pub struct UpdateCommand {}
+pub struct UpdateCommand;
+crate::command!(UpdateCommand);
 
-impl Command for UpdateCommand {
+#[async_trait]
+impl CommandRunnable for UpdateCommand {
     fn name(&self) -> String {
         String::from("update")
     }
@@ -30,10 +32,7 @@ impl Command for UpdateCommand {
                 .long("prerelease")
                 .action(clap::ArgAction::SetTrue))
     }
-}
 
-#[async_trait]
-impl CommandRunnable for UpdateCommand {
     #[tracing::instrument(name = "gt update", err, skip(self, core, matches))]
     async fn run(
         &self,
@@ -161,6 +160,7 @@ where {
 #[cfg(test)]
 mod tests {
     use crate::console::MockConsoleProvider;
+    use std::sync::Arc;
 
     use super::*;
 


### PR DESCRIPTION
This is a code refactor intended to simplify the introduction of new commands by centralizing registration through the `inventory` crate.