### PR TITLE
feat: Add support for resolving scratchpads relative to the current week

### DIFF
--- a/src/commands/scratch.rs
+++ b/src/commands/scratch.rs
@@ -72,6 +72,9 @@ impl CommandRunnable for ScratchCommand {
         skip(self, core, completer, _matches)
     )]
     async fn complete(&self, core: &Core, completer: &Completer, _matches: &ArgMatches) {
+        let time = chrono::Local::now();
+        completer.offer(&time.format("%Yw%V").to_string());
+
         completer.offer_many(core.config().get_apps().map(|a| a.get_name()));
 
         if let Ok(pads) = core.resolver().get_scratchpads() {

--- a/src/commands/scratch.rs
+++ b/src/commands/scratch.rs
@@ -73,7 +73,7 @@ impl CommandRunnable for ScratchCommand {
     )]
     async fn complete(&self, core: &Core, completer: &Completer, _matches: &ArgMatches) {
         let time = chrono::Local::now();
-        completer.offer(&time.format("%Yw%V").to_string());
+        completer.offer(time.format("%Yw%V").to_string());
 
         completer.offer_many(core.config().get_apps().map(|a| a.get_name()));
 

--- a/src/completion/completer.rs
+++ b/src/completion/completer.rs
@@ -18,7 +18,8 @@ impl Completer {
         }
     }
 
-    pub fn offer(&self, completion: &str) {
+    pub fn offer<S: AsRef<str>>(&self, completion: S) {
+        let completion = completion.as_ref();
         if !matches(completion, &self.filter) {
             return;
         }

--- a/src/core/resolver.rs
+++ b/src/core/resolver.rs
@@ -422,6 +422,9 @@ mod tests {
                     .to_string()
             )
         );
+
+        assert!(resolver.get_scratchpad("^not-a-number").is_err());
+        assert!(resolver.get_scratchpad("^-1").is_err());
     }
 
     #[test]


### PR DESCRIPTION
This PR introduces the ability to run commands like `gt scratch ~5` or `gt scratch ^2` to resolve the scratchpad from (respectively) 5 weeks ago or 2 weeks ago. This closes #1295 