### PR TITLE
feat: Add a `gt temp` command to create a temporary directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 shell-words = "1.1"
+tempfile = "3.16"
 tokio = { version = "1.43", features = [
   "rt",
   "time",
@@ -50,7 +51,6 @@ trust-dns-resolver = { version = "0.23", features = ["tokio-runtime"] }
 
 [dev-dependencies]
 mockall = "0.13.1"
-tempfile = "3.16"
 sentry = { version = "0.36", default-features = false, features = [
   "reqwest",
   "rustls",

--- a/docs/.vuepress/components/Releases.vue
+++ b/docs/.vuepress/components/Releases.vue
@@ -4,32 +4,17 @@
 
     <div class="release-platforms">
       <div>Select your Platform:</div>
-      <button
-        class="release-button release-platform"
-        :class="{ active: platform === selectedPlatform }"
-        v-for="(name, platform) in platforms"
-        :key="platform"
-        v-on:click="selectedPlatform = platform"
-      >
+      <button class="release-button release-platform" :class="{ active: platform === selectedPlatform }"
+        v-for="(name, platform) in platforms" :key="platform" v-on:click="selectedPlatform = platform">
         {{ name }}
       </button>
     </div>
 
     <div class="release-list" v-if="selectedPlatform">
-      <div
-        class="release"
-        v-for="release in applicableReleases"
-        :key="release.id"
-      >
+      <div class="release" v-for="release in applicableReleases" :key="release.id">
         <h4 class="release__name">
-          <a
-            class="release-button"
-            :href="
-              getReleaseAsset(release, selectedPlatform).browser_download_url
-            "
-            target="_blank"
-            >Download</a
-          >
+          <a class="release-button no-external-link-icon" :href="getReleaseAsset(release, selectedPlatform).browser_download_url
+            " target="_blank">Download</a>
 
           {{ release.name }}
           <Badge v-if="release.prerelease" text="Early Access" type="warning" />
@@ -137,6 +122,11 @@ export default defineComponent({
   margin: 20px;
 }
 
+.release__name {
+  margin-top: 1em;
+  padding-top: 0;
+}
+
 .release__notes {
   white-space: pre-wrap;
   word-break: break-word;
@@ -152,8 +142,8 @@ export default defineComponent({
 }
 
 .release-platform.active {
-  background: var(--c-brand);
-  color: var(--c-bg);
+  background: var(--vp-c-accent-bg);
+  color: var(--vp-c-accent-text);
 }
 
 .release-assets {
@@ -173,17 +163,22 @@ export default defineComponent({
 .release-button {
   background: none;
   border-radius: 5px;
-  color: var(--c-brand);
-  border: 1px solid var(--c-brand);
+  background: var();
+  color: var(--vp-c-accent-bg);
+  border: 1px solid var(--vp-c-accent-bg);
   font-size: 80%;
   padding: 7px;
   margin: 5px;
   cursor: pointer;
 }
 
+a.release-button {
+  text-decoration: none;
+}
+
 .release-button:hover,
 .release-button:focus {
-  background: var(--c-brand-light);
-  color: var(--c-bg);
+  background: var(--vp-c-accent-hover);
+  color: var(--vp-c-accent-text);
 }
 </style>

--- a/docs/commands/scratch.md
+++ b/docs/commands/scratch.md
@@ -50,9 +50,39 @@ gt s code
 # Open a specially named scratchpad folder
 gt s 2021w10-super-important
 ```
- 
+
 ::: tip
 You don't need to use our naming scheme if you don't want to, just run `gt s something` and
 we'll create a `something` folder for you with no complaints. *This can be useful if you
 have an important project which you don't want to lose track of.*
+:::
+
+## temp <Badge text="v3.6.0+" />
+The `gt temp` command is a shortcut for opening a temporary scratchpad which is automatically
+deleted when you close the launched application. This is useful when you want to quickly test
+something without leaving a mess behind.
+
+::: tip
+The `gt temp` command creates a temporary folder in your current user's temporary directory
+and launches the specified application in that folder. When the application exits, the folder
+will be automatically deleted.
+:::
+
+#### Example
+```powershell
+# Open a temporary scratchpad in your default app
+gt temp
+
+# Open a temporary scratchpad in PowerShell
+gt temp pwsh
+
+# Open a temporary scratchpad and don't delete it when you're done
+gt temp --keep
+```
+
+::: warning
+Applications which exit immediately after launching (like VSCode's `code` command) will cause
+the temporary folder to be deleted immediately after the application is launched. You can prevent
+this by using the `--keep` flag to prevent the folder from being deleted - however you will need
+to manually clean it up when you're done (in this case it works much the same as a standard scratchpad).
 :::

--- a/docs/commands/scratch.md
+++ b/docs/commands/scratch.md
@@ -71,7 +71,7 @@ will be automatically deleted.
 #### Example
 ```powershell
 # Open a temporary scratchpad in your default app
-gt temp
+gt t
 
 # Open a temporary scratchpad in PowerShell
 gt temp pwsh

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,9 +8,6 @@
       "name": "git-tool-docs",
       "version": "1.0.0",
       "license": "MIT",
-      "dependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.34.1"
-      },
       "devDependencies": {
         "@vuepress/bundler-vite": "2.0.0-rc.19",
         "@vuepress/plugin-google-analytics": "2.0.0-rc.66",

--- a/flake.nix
+++ b/flake.nix
@@ -111,6 +111,7 @@
           nativeBuildInputs = with pkgs; [
             cargo
             rustc
+            nodejs
           ] ++ nativeBuildInputs ++ buildInputs;
         };
       });

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -30,6 +30,7 @@ mod services;
 mod setup;
 mod shell_init;
 mod switch;
+mod temp;
 mod update;
 
 inventory::collect!(Command);

--- a/src/commands/temp.rs
+++ b/src/commands/temp.rs
@@ -1,5 +1,6 @@
 use super::async_trait;
 use super::*;
+use crate::core::Target;
 use clap::Arg;
 use tracing_batteries::prelude::*;
 
@@ -43,9 +44,13 @@ impl CommandRunnable for TempCommand {
               "Make sure that you add an app to your config file using 'git-tool config add apps/bash' or similar."))?
         };
 
-        let temp = core
-            .resolver()
-            .get_temp(matches.get_one::<bool>("keep").copied().unwrap_or_default())?;
+        let keep = matches.get_one::<bool>("keep").copied().unwrap_or_default();
+
+        let temp = core.resolver().get_temp(keep)?;
+
+        if keep {
+            writeln!(core.output(), "temp path: {}", temp.get_path().display())?;
+        }
 
         let status = core.launcher().run(app, &temp).await?;
         temp.close()?;

--- a/src/commands/temp.rs
+++ b/src/commands/temp.rs
@@ -16,7 +16,7 @@ impl CommandRunnable for TempCommand {
     fn app(&self) -> clap::Command {
         clap::Command::new(self.name())
             .version("1.0")
-            .visible_alias("s")
+            .visible_alias("t")
             .about("opens a temporary folder which will be removed when the shell is closed")
             .arg(
                 Arg::new("app")

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -33,7 +33,7 @@ pub use repo::Repo;
 pub use resolver::Resolver;
 pub use scratchpad::Scratchpad;
 pub use service::{Service, ServiceAPI};
-pub use target::Target;
+pub use target::{Target, TempTarget};
 
 pub struct Core {
     config: Arc<Config>,

--- a/src/core/resolver.rs
+++ b/src/core/resolver.rs
@@ -11,7 +11,7 @@ use mockall::automock;
 
 #[cfg_attr(test, automock)]
 pub trait Resolver: Send + Sync {
-    fn get_temp(&self) -> Result<TempTarget, Error>;
+    fn get_temp(&self, keep: bool) -> Result<TempTarget, Error>;
 
     fn get_scratchpads(&self) -> Result<Vec<Scratchpad>, Error>;
     fn get_scratchpad(&self, name: &str) -> Result<Scratchpad, Error>;
@@ -39,8 +39,8 @@ impl From<Arc<Config>> for TrueResolver {
 
 impl Resolver for TrueResolver {
     #[tracing::instrument(err, skip(self))]
-    fn get_temp(&self) -> Result<TempTarget, Error> {
-        TempTarget::new()
+    fn get_temp(&self, keep: bool) -> Result<TempTarget, Error> {
+        TempTarget::new(keep)
     }
 
     #[tracing::instrument(err, skip(self))]

--- a/src/core/resolver.rs
+++ b/src/core/resolver.rs
@@ -1,5 +1,5 @@
 use super::features::ALWAYS_OPEN_BEST_MATCH;
-use super::{errors, Config, Error, Repo, Scratchpad, Service};
+use super::{errors, Config, Error, Repo, Scratchpad, Service, TempTarget};
 use crate::{fs::to_native_path, search};
 use chrono::prelude::*;
 use std::env;
@@ -11,6 +11,8 @@ use mockall::automock;
 
 #[cfg_attr(test, automock)]
 pub trait Resolver: Send + Sync {
+    fn get_temp(&self) -> Result<TempTarget, Error>;
+
     fn get_scratchpads(&self) -> Result<Vec<Scratchpad>, Error>;
     fn get_scratchpad(&self, name: &str) -> Result<Scratchpad, Error>;
     fn get_current_scratchpad(&self) -> Result<Scratchpad, Error>;
@@ -36,6 +38,11 @@ impl From<Arc<Config>> for TrueResolver {
 }
 
 impl Resolver for TrueResolver {
+    #[tracing::instrument(err, skip(self))]
+    fn get_temp(&self) -> Result<TempTarget, Error> {
+        TempTarget::new()
+    }
+
     #[tracing::instrument(err, skip(self))]
     fn get_scratchpads(&self) -> Result<Vec<Scratchpad>, Error> {
         let dirs = self.config.get_scratch_directory().read_dir().map_err(|err| errors::user_with_internal(

--- a/src/core/target.rs
+++ b/src/core/target.rs
@@ -9,3 +9,44 @@ pub trait Target: Display {
     fn exists(&self) -> bool;
     fn template_context(&self, config: &Config) -> Value;
 }
+
+pub struct TempTarget {
+    dir: tempfile::TempDir,
+}
+
+impl TempTarget {
+    pub fn new() -> Result<Self, crate::errors::Error> {
+        Ok(Self {
+            dir: tempfile::tempdir()?,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn with_dir(dir: tempfile::TempDir) -> Self {
+        Self { dir }
+    }
+}
+
+impl Target for TempTarget {
+    fn get_name(&self) -> String {
+        "temp".to_string()
+    }
+
+    fn get_path(&self) -> std::path::PathBuf {
+        self.dir.path().to_owned()
+    }
+
+    fn exists(&self) -> bool {
+        true
+    }
+
+    fn template_context(&self, _config: &Config) -> Value {
+        self.into()
+    }
+}
+
+impl Display for TempTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "temp")
+    }
+}

--- a/src/core/templates.rs
+++ b/src/core/templates.rs
@@ -1,4 +1,4 @@
-use super::{errors, Config, Repo, Scratchpad, Service, Target};
+use super::{errors, target::TempTarget, Config, Repo, Scratchpad, Service, Target};
 use gtmpl::{template, Value};
 use tracing_batteries::prelude::*;
 
@@ -125,6 +125,21 @@ impl std::convert::Into<Value> for &Repo {
 
 #[allow(clippy::from_over_into)]
 impl std::convert::Into<Value> for &Scratchpad {
+    fn into(self) -> Value {
+        Value::Object(map! {
+            "Target" => Value::Object(map!{
+                "Name" => Value::String(self.get_name()),
+                "Path" => Value::String(String::from(self.get_path().to_str().unwrap_or_default())),
+                "Exists" => Value::Bool(self.exists())
+            }),
+            "Repo" => Value::NoValue,
+            "Service" => Value::NoValue
+        })
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl std::convert::Into<Value> for &TempTarget {
     fn into(self) -> Value {
         Value::Object(map! {
             "Target" => Value::Object(map!{


### PR DESCRIPTION
This pull request adds a new `gt temp` command to create a temporary directory which will be automatically deleted when the active process terminates. It's particularly useful for playing with something you don't intend on keeping (such as testing out a language feature).

```bash
# Open a temp scratchpad in the default app
gt temp

# Open a temp scratchpad in PowerShell
gt temp pwsh

# Open a temp scratchpad and don't delete it when you're done
gt temp --keep
```