### PR TITLE
feat: Add support for importing a file list of repos

### DIFF
--- a/docs/commands/repos.md
+++ b/docs/commands/repos.md
@@ -59,7 +59,7 @@ gt o vs
 # Open a repository in VS Code
 gt o gh:SierraSoftworks/git-tool code
 ```
- 
+
 ::: tip
 If you are already inside a repository, you can specify only an app and it will launch in the
 context of the current repo, like `gt o vs` in the example above. *This can be very useful if
@@ -161,7 +161,22 @@ new dev-box, this is the command for you.
 ```powershell
 # Clone a repository into the appropriate folder
 gt clone gh:SierraSoftworks/git-tool
+
+# Clone a series of repositories into the appropriate folders
+# The repositories.txt file should contain a list of repositories, one per line
+# e.g.
+#   gh:SierraSoftworks/git-tool
+#   gh:SierraSoftworks/tailscale-udm
+#   gh:SierraSoftworks/vue-template
+gt clone @repositories.txt
 ```
+
+::: tip
+As of <Badge text="v3.7.0+"/>, you can use the `@` symbol to specify a file
+containing a list of repositories to clone. This can be paired with
+[`gt list -q`](#list) to quickly backup and restore your list of local repositories,
+or setup a new machine.
+:::
 
 ## fix <Badge text="v2.1.4+"/>
 Git-Tool usually takes care of setting up your git `origin` remote, however sometimes you

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,9 +8,6 @@
       "name": "git-tool-docs",
       "version": "1.0.0",
       "license": "MIT",
-      "dependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.34.6"
-      },
       "devDependencies": {
         "@vuepress/bundler-vite": "2.0.0-rc.19",
         "@vuepress/plugin-google-analytics": "2.0.0-rc.66",

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -32,9 +32,9 @@ impl CommandRunnable for CloneCommand {
             "You didn't specify the repository you wanted to clone.",
             "Remember to specify a repository name like this: 'git-tool clone gh:sierrasoftworks/git-tool'."))?;
 
-        if repo_name.starts_with('@') {
+        if let Some(file_path) = repo_name.strip_prefix('@') {
             // Load the list of repos to clone from a file
-            let file_path: PathBuf = repo_name[1..].parse().map_err(|e| {
+            let file_path: PathBuf = file_path.parse().map_err(|e| {
                 errors::user_with_internal(
                     "The specified file path is not valid.",
                     "Please make sure you are specifying a valid file path for your import file.",


### PR DESCRIPTION
This PR adds a new `gt clone @file` command which allows you to import a list of repositories from a file, simplifying migration from one machine to another.

The workflow would involve something like the following:

```
# Create a list of your repos
gt list -q > repos.txt

# Restore those repos from their upstream sources
gt clone @repos.txt
```