### PR TITLE
add new command to easily rename a git-repository

### DIFF
--- a/docs/commands/repos.md
+++ b/docs/commands/repos.md
@@ -1,29 +1,33 @@
 # Repositories
+
 Git-Tool's main purpose is managing your local development directory, ensuring
 that your repositories are kept organized and are available when you need them
 with a minimum amount of cognitive effort on your part.
 
 #### Directory Structure
+
 Git-Tool uses a directory structure very similar to `GOPATH`. If you're curious
-why we've chosen this approach, please read my [blog post](https://blog.sierrasoftworks.com/2019/04/15/git-tool/#background)
+why we've chosen this approach, please read
+my [blog post](https://blog.sierrasoftworks.com/2019/04/15/git-tool/#background)
 on the topic. If you are simply curious what that means, here's an example:
 
 <FileTree>
 
- - dev
-   - github.com
-     - notheotherben
-         - cv
-     - sierrasoftworks
-         - bender
-         - blog
-         - git-tool
-         - iridium
-         - vue-template
+- dev
+    - github.com
+        - notheotherben
+            - cv
+        - sierrasoftworks
+            - bender
+            - blog
+            - git-tool
+            - iridium
+            - vue-template
+
 </FileTree>
 
-
 ## open <Badge text="v1.0+"/>
+
 The first place you're likely to start with Git-Tool is opening a repo you want to work on.
 To do so, you'll use the `gt open` command, which allows you to launch a shell (or any other
 app you have defined in your [config](../config/README.md)) inside that repository's directory.
@@ -38,17 +42,19 @@ New applications can be configured either by making changes to your configuratio
 can use `gtconfig add apps/bash` to configure `bash` as an available app.
 
 #### Aliases
- - `gt open`
- - `gt o`
- - `gt run`
 
+- `gt open`
+- `gt o`
+- `gt run`
 
 #### Options
- - `-c`/`--create` <Badge text="v2.1+"/> will create a new repository if one with this name doesn't exist locally.
- - `-R`/`--no-create-remote` <Badge text="v2.1+"/> will disable the [creation of a remote repository](../config/features.md#create-remote) when run with `-c`.
 
+- `-c`/`--create` <Badge text="v2.1+"/> will create a new repository if one with this name doesn't exist locally.
+- `-R`/`--no-create-remote` <Badge text="v2.1+"/> will disable
+  the [creation of a remote repository](../config/features.md#create-remote) when run with `-c`.
 
 #### Example
+
 ```powershell
 # Open a repository in your default application
 gt o gh:SierraSoftworks/git-tool
@@ -68,6 +74,7 @@ Studio developer console).*
 :::
 
 ## new <Badge text="v1.0+"/>
+
 There's nothing new under the sun, but sometimes we like to build it anyway. If you're starting
 something new and want a fresh repo for it, the `gt new` command is your best friend. It will
 create and `git init` your repo, setup your remote hosting provider (if supported).
@@ -77,16 +84,23 @@ repository to appear in (such as `github.com/notheotherben/` and `github.com/Sie
 helping you quickly figure out where your repo should be created.
 
 #### Aliases
- - `gt new`
- - `gt n`
- - `gt create`
+
+- `gt new`
+- `gt n`
+- `gt create`
 
 #### Options
- - `-R`/`--no-create-remote` <Badge text="v2.1+"/> will disable the [creation of a remote repository](../config/features.md#create-remote).
- - `-E`/`--no-check-exists` <Badge text="v3.3+"/> will disable [checking if the repository already exists](../config/features.md#check-exists).
- - `-o`/`--open` <Badge text="v2.1+"/> will open this repository in your default application once it has been created. You can make this behaviour the default with the [`open_new_repo_in_default_app`](../config/features.md#open-new-repo-in-default-app) feature flag.
+
+- `-R`/`--no-create-remote` <Badge text="v2.1+"/> will disable
+  the [creation of a remote repository](../config/features.md#create-remote).
+- `-E`/`--no-check-exists` <Badge text="v3.3+"/> will
+  disable [checking if the repository already exists](../config/features.md#check-exists).
+- `-o`/`--open` <Badge text="v2.1+"/> will open this repository in your default application once it has been created.
+  You can make this behaviour the default with the [
+  `open_new_repo_in_default_app`](../config/features.md#open-new-repo-in-default-app) feature flag.
 
 #### Example
+
 ```powershell
 # Create a new repository
 gt n gh:notheotherben/demo
@@ -99,6 +113,7 @@ gt n --no-create-remote gh:notheotherben/demo
 ```
 
 ## list <Badge text="v1.0+"/>
+
 If you're trying to get a list of your repositories, Git-Tool has you covered. The `gt list`
 command will show you all of your locally cloned repositories and can be a useful tool if you
 need to (for example) write a script which performs a task across all of them.
@@ -109,15 +124,19 @@ If you are migrating machines and want to clone your repositories, you can dump 
 :::
 
 #### Aliases
- - `gt list`
- - `gt ls`
- - `gt ll`
+
+- `gt list`
+- `gt ls`
+- `gt ll`
 
 #### Options
- - `-q`/`--quiet` will limit the output to only the repository's name. This output is useful for consumption by scripts.
- - `--full` will print out a series of YAML documents, using `---` document separators, which contain detailed information about each of your repositories.
+
+- `-q`/`--quiet` will limit the output to only the repository's name. This output is useful for consumption by scripts.
+- `--full` will print out a series of YAML documents, using `---` document separators, which contain detailed
+  information about each of your repositories.
 
 #### Example
+
 ```powershell
 # List your repositories (and their web addresses)
 gt ls
@@ -130,16 +149,18 @@ gt ls --full gh:SierraSoftworks/sierralib
 ```
 
 ## info <Badge text="v1.0+"/>
+
 If you want to get access to some of the detailed information about a repository managed by Git-Tool,
 including things like the URLs associated with it or the path to the repo, you can use the `gt info`
 command.
 
 #### Aliases
- - `gt info`
- - `gt i`
 
+- `gt info`
+- `gt i`
 
 #### Example
+
 ```powershell
 # Get information about the current repository
 gt i
@@ -153,11 +174,13 @@ You can omit the repository name if you want to get information about your curre
 :::
 
 ## clone <Badge text="v2.1.19+"/>
+
 The `gt clone` command does everything the `gt open` command does, except open an application.
 If you're trying to quickly clone a list of repositories, such as when you're setting up your
 new dev-box, this is the command for you.
 
 #### Example
+
 ```powershell
 # Clone a repository into the appropriate folder
 gt clone gh:SierraSoftworks/git-tool
@@ -179,15 +202,18 @@ or setup a new machine.
 :::
 
 ## fix <Badge text="v2.1.4+"/>
+
 Git-Tool usually takes care of setting up your git `origin` remote, however sometimes you
 want to rename projects or even entire organizations. To make your life a little bit easier,
 the `gt fix` command will update your git `origin` remote to reflect the current repo information
 shown in [`gt info`](#info) (which is based on its filesystem path).
 
 #### Options
- - `--all` will fix any repositories which match the provided pattern.
+
+- `--all` will fix any repositories which match the provided pattern.
 
 #### Example
+
 ```powershell
 # Fix the git remote configuration for a single repository
 gt fix gh:SierraSoftworks/git-tool
@@ -202,12 +228,65 @@ The quickest way to update a repo's `origin` is to `mv $REPO $NEW_REPO` and then
 :::
 
 ## remove <Badge text="v2.2.13+"/>
+
 The `gt remove` command will remove a repository from your local machine. This is particularly
 useful since a repository you have opened with [`gt open`](#open) will often have its shell spawned
 in the directory you are attempting to delete.
 
 #### Example
+
 ```powershell
 # Remove a repository
 gt remove gh:SierraSoftworks/git-tool
+```
+
+## rename <Badge text="v3.8.0+"/>
+
+The `gt rename` command will rename a repository on your local machine and updates the
+origin URL to match the new name.
+
+::: note
+
+In case you have a directory layout like this:
+
+<FileTree>
+
+- dev
+    - github.com
+        - sierrasoftworks
+            - git-tool
+
+</FileTree>
+
+but multiple remotes configured in the `git-tool` repository:
+
+- `origin git@github.com:SpechtLabs/git-tool.git`
+- `upstream git@github.com:SierraSoftworks/git-tool.git`
+
+the `gt rename` command will only update the remote who's URL matches the expected git-remote based on the directory
+structure.
+In this example, `gt rename gh:SierraSoftworks/git-tool gh:SierraSoftworks/gt` will result in the following remote
+configuration:
+
+- `origin git@github.com:SpechtLabs/git-tool.git`
+- `upstream git@github.com:SierraSoftworks/gt.git`
+
+:::
+
+#### Aliases
+
+- `gt mv`
+
+#### Options
+
+- `--no-update-remote` will cause the command to not update the remote URL.
+
+#### Example
+
+```powershell
+# Rename a repository locally and not update the remote URL
+gt mv gh:SierraSoftworks/git-tool gh:SierraSoftworks/gt --no-update-remote
+
+# Rename a repository and update the remote URL
+gt mv gh:SierraSoftworks/gt gh:SierraSoftworks/git-tool
 ```

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -25,6 +25,7 @@ mod new;
 mod open;
 mod prune;
 mod remove;
+mod rename;
 mod scratch;
 mod services;
 mod setup;
@@ -32,7 +33,6 @@ mod shell_init;
 mod switch;
 mod temp;
 mod update;
-
 inventory::collect!(Command);
 
 #[macro_export]

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -1,0 +1,356 @@
+use super::*;
+use crate::core::Target;
+use crate::tasks::*;
+use clap::Arg;
+use tracing_batteries::prelude::*;
+
+pub struct RenameCommand;
+crate::command!(RenameCommand);
+
+#[async_trait]
+impl CommandRunnable for RenameCommand {
+    fn name(&self) -> String {
+        String::from("rename")
+    }
+
+    fn app(&self) -> clap::Command {
+        clap::Command::new(self.name())
+            .about("renames a repository on your local machine")
+            .long_about("This command will rename the specified repository on your local machine. It requires that the repository name be provided in fully-qualified form.")
+            .visible_aliases(["mv"])
+            .arg(Arg::new("repo")
+                .help("The name of the repository to rename.")
+                .long_help("The repository to be renamed in fully-qualified form.")
+                .index(1)
+                .required(true))
+            .arg(Arg::new("new_name")
+                .help("The new name of the repository.")
+                .long_help("The new name of the repository must not be in fully-qualified form.")
+                .index(2)
+                .required(true))
+            .arg(Arg::new("no-update-remote")
+                .long("no-update-remote")
+                .help("Also update the git remote URL after renaming.")
+                .action(clap::ArgAction::SetTrue))
+    }
+
+    #[tracing::instrument(name = "gt rename", err, skip(self, core, matches))]
+    async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, errors::Error> {
+        let no_update_remote = matches.get_flag("no-update-remote");
+        let repo_name = matches.get_one::<String>("repo").ok_or_else(|| {
+            errors::user(
+                "The repository name to be moved was not provided and cannot be moved as a result.",
+                "Make sure to provide the name of the repository you want to rename.",
+            )
+        })?;
+
+        let new_name = matches.get_one::<String>("new_name").ok_or_else(|| {
+            errors::user(
+                format!("The new repository name to rename your repository {} to was not provided and cannot be moved as a result.", repo_name).as_str(),
+                "Make sure to provide the new name of the repository you want to rename."
+            )
+        })?;
+
+        let repo = core.resolver().get_best_repo(repo_name)?;
+        if !repo.exists() {
+            return Err(errors::user(
+                "Could not find the repository directory due to an error.",
+                "Make sure you have the correct permissions to rename the directory. Remember to specify a repository name in it's fully-qualified form like this: 'git-tool rename gh:sierrasoftworks/git-tool gt'.")
+            );
+        }
+
+        let new_repo = core.resolver().get_best_repo(new_name)?;
+
+        // Update the Git-Remote
+        if !no_update_remote {
+            GitMoveUpstream {
+                new_repo: new_repo.clone(),
+            }
+            .apply_repo(&core, &repo.clone())
+            .await?;
+        }
+
+        let move_task = MoveDirectory {
+            new_path: new_repo.path.clone(),
+        };
+
+        // Move the directory
+        if let Err(err) = move_task.apply_repo(&core, &repo).await {
+            // Roll back the Git-remote change if needed
+            if !no_update_remote {
+                if let Err(rollback_err) = (GitRemote { name: "origin" })
+                    .apply_repo(&core, &repo)
+                    .await
+                {
+                    tracing::warn!(
+                        error = ?rollback_err,
+                        "Failed to roll back Git remote change after move failure"
+                    );
+                }
+            }
+
+            return Err(err);
+        }
+
+        assert!(new_repo.valid());
+
+        Ok(0)
+    }
+
+    #[tracing::instrument(
+        name = "gt complete -- gt rename",
+        skip(self, core, completer, _matches)
+    )]
+    async fn complete(&self, core: &Core, completer: &Completer, _matches: &ArgMatches) {
+        completer.offer("--update-git-remote");
+
+        completer.offer_many(core.config().get_aliases().map(|(a, _)| a));
+        completer.offer_many(core.config().get_apps().map(|a| a.get_name()));
+
+        let default_svc = core
+            .config()
+            .get_default_service()
+            .map(|s| s.name.clone())
+            .unwrap_or_default();
+
+        if let Ok(repos) = core.resolver().get_repos() {
+            completer.offer_many(
+                repos
+                    .iter()
+                    .filter(|r| r.service == default_svc)
+                    .map(|r| r.get_full_name()),
+            );
+            completer.offer_many(
+                repos
+                    .iter()
+                    .map(|r| format!("{}:{}", &r.service, r.get_full_name())),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::git::git_remote_get_url;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn rename_repo_update_upstream() {
+        let cmd = RenameCommand {};
+
+        let args = cmd.app().get_matches_from(vec![
+            "rename",
+            "gh:git-fixtures/basic",
+            "gh:git-fixtures/renamed",
+        ]);
+
+        let temp = tempdir().unwrap();
+        let core = Core::builder()
+            .with_config_for_dev_directory(temp.path())
+            .with_null_console()
+            .build();
+
+        let repo = core
+            .resolver()
+            .get_best_repo("gh:git-fixtures/basic")
+            .unwrap();
+
+        GitClone {}.apply_repo(&core, &repo).await.unwrap();
+
+        assert!(repo.path.exists());
+        assert!(repo.valid());
+
+        let remote = git_remote_get_url(&repo.path, "origin").await;
+        assert!(remote.is_ok());
+
+        let remote_list = remote.unwrap();
+        assert_eq!(remote_list.len(), 1);
+        let remote_url = remote_list.first().unwrap();
+        assert!(
+            remote_url.contains("git-fixtures/basic"),
+            "Unexpected remote url: {remote_url}"
+        );
+
+        match cmd.run(&core, &args).await {
+            Ok(status) => {
+                assert_eq!(status, 0, "the command should exit successfully");
+            }
+            Err(err) => panic!("{}", err.message()),
+        }
+
+        assert!(
+            !repo.path.exists(),
+            "the repo should be moved to the correct directory"
+        );
+
+        let new_repo = core
+            .resolver()
+            .get_best_repo("gh:git-fixtures/renamed")
+            .unwrap();
+
+        assert!(
+            new_repo.path.exists(),
+            "the repo should be moved to the correct directory"
+        );
+
+        let remote = git_remote_get_url(&new_repo.path, "origin").await;
+        assert!(remote.is_ok());
+
+        let remote_list = remote.unwrap();
+        assert_eq!(remote_list.len(), 1);
+        let remote_url = remote_list.first().unwrap();
+        assert!(
+            remote_url.contains("git-fixtures/renamed"),
+            "Unexpected remote url: {remote_url}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rename_repo_no_update_upstream() {
+        let cmd = RenameCommand {};
+
+        let args = cmd.app().get_matches_from(vec![
+            "rename",
+            "gh:git-fixtures/basic",
+            "gh:git-fixtures/renamed",
+            "--no-update-remote",
+        ]);
+
+        let temp = tempdir().unwrap();
+        let core = Core::builder()
+            .with_config_for_dev_directory(temp.path())
+            .with_null_console()
+            .build();
+
+        let repo = core
+            .resolver()
+            .get_best_repo("gh:git-fixtures/basic")
+            .unwrap();
+
+        GitClone {}.apply_repo(&core, &repo).await.unwrap();
+
+        assert!(repo.path.exists());
+        assert!(repo.valid());
+
+        let remote = git_remote_get_url(&repo.path, "origin").await;
+        assert!(remote.is_ok());
+
+        let remote_list = remote.unwrap();
+        assert_eq!(remote_list.len(), 1);
+        let remote_url = remote_list.first().unwrap();
+        assert!(
+            remote_url.contains("git-fixtures/basic"),
+            "Unexpected remote url: {remote_url}"
+        );
+
+        match cmd.run(&core, &args).await {
+            Ok(status) => {
+                assert_eq!(status, 0, "the command should exit successfully");
+            }
+            Err(err) => panic!("{}", err.message()),
+        }
+
+        assert!(
+            !repo.path.exists(),
+            "the repo should be moved to the correct directory"
+        );
+
+        let new_repo = core
+            .resolver()
+            .get_best_repo("gh:git-fixtures/renamed")
+            .unwrap();
+
+        assert!(
+            new_repo.path.exists(),
+            "the repo should be moved to the correct directory"
+        );
+
+        let remote = git_remote_get_url(&new_repo.path, "origin").await;
+        assert!(remote.is_ok());
+
+        let remote_list = remote.unwrap();
+        assert_eq!(remote_list.len(), 1);
+        assert_ne!(
+            remote_list.first().unwrap(),
+            "git@github.com:git-fixtures/renamed.git"
+        );
+
+        let remote_url = remote_list.first().unwrap();
+        assert!(
+            remote_url.contains("git-fixtures/basic"),
+            "Unexpected remote url: {remote_url}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rename_folder_should_not_work() {
+        let cmd = RenameCommand {};
+
+        let args = cmd.app().get_matches_from(vec![
+            "rename",
+            "gh:git-fixtures/basic",
+            "gh:fixtures/basic",
+        ]);
+
+        let temp = tempdir().unwrap();
+        let core = Core::builder()
+            .with_config_for_dev_directory(temp.path())
+            .with_null_console()
+            .build();
+
+        let repo = core
+            .resolver()
+            .get_best_repo("gh:git-fixtures/basic")
+            .unwrap();
+
+        GitClone {}.apply_repo(&core, &repo).await.unwrap();
+
+        assert!(repo.path.exists());
+        assert!(repo.valid());
+
+        let remote = git_remote_get_url(&repo.path, "origin").await;
+        assert!(remote.is_ok());
+
+        let remote_list = remote.unwrap();
+        assert_eq!(remote_list.len(), 1);
+        let remote_url = remote_list.first().unwrap();
+        assert!(
+            remote_url.contains("git-fixtures/basic"),
+            "Unexpected remote url: {remote_url}"
+        );
+
+        match cmd.run(&core, &args).await {
+            Ok(status) => {
+                assert_ne!(status, 0, "the command should not exit successfully");
+            }
+            Err(err) => {
+                assert!(
+                    err.message()
+                        .contains("Could not rename the repository directory"),
+                    "the command should not allow renaming the directory"
+                )
+            }
+        }
+
+        assert!(repo.path.exists(), "the repo should not be moved");
+
+        let new_repo = core.resolver().get_best_repo("gh:fixtures/basic").unwrap();
+
+        assert!(
+            !new_repo.path.exists(),
+            "the repo should be moved to the new directory, therefore the new directory should not exist"
+        );
+
+        let remote = git_remote_get_url(&repo.path, "origin").await;
+        assert!(remote.is_ok());
+
+        let remote_list = remote.unwrap();
+        assert_eq!(remote_list.len(), 1);
+        let remote_url = remote_list.first().unwrap();
+        assert!(
+            remote_url.contains("git-fixtures/basic"),
+            "Unexpected remote url: {remote_url}"
+        );
+    }
+}

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -105,7 +105,6 @@ impl CommandRunnable for RenameCommand {
         completer.offer("--update-git-remote");
 
         completer.offer_many(core.config().get_aliases().map(|(a, _)| a));
-        completer.offer_many(core.config().get_apps().map(|a| a.get_name()));
 
         let default_svc = core
             .config()

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -134,6 +134,7 @@ mod tests {
     use tempfile::tempdir;
 
     #[tokio::test]
+    #[cfg_attr(feature = "pure-tests", ignore)]
     async fn rename_repo_update_upstream() {
         let cmd = RenameCommand {};
 
@@ -205,6 +206,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(feature = "pure-tests", ignore)]
     async fn rename_repo_no_update_upstream() {
         let cmd = RenameCommand {};
 
@@ -282,6 +284,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(feature = "pure-tests", ignore)]
     async fn rename_folder_should_not_work() {
         let cmd = RenameCommand {};
 

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -66,7 +66,7 @@ impl CommandRunnable for RenameCommand {
             GitMoveUpstream {
                 new_repo: new_repo.clone(),
             }
-            .apply_repo(&core, &repo.clone())
+            .apply_repo(core, &repo.clone())
             .await?;
         }
 
@@ -75,12 +75,11 @@ impl CommandRunnable for RenameCommand {
         };
 
         // Move the directory
-        if let Err(err) = move_task.apply_repo(&core, &repo).await {
+        if let Err(err) = move_task.apply_repo(core, &repo).await {
             // Roll back the Git-remote change if needed
             if !no_update_remote {
-                if let Err(rollback_err) = (GitRemote { name: "origin" })
-                    .apply_repo(&core, &repo)
-                    .await
+                if let Err(rollback_err) =
+                    (GitRemote { name: "origin" }).apply_repo(core, &repo).await
                 {
                     tracing::warn!(
                         error = ?rollback_err,

--- a/src/core/target.rs
+++ b/src/core/target.rs
@@ -1,7 +1,6 @@
-use std::fmt::Display;
-
 use super::Config;
 use gtmpl::Value;
+use std::fmt::Display;
 
 pub trait Target: Display {
     fn get_name(&self) -> String;

--- a/src/git/cmd.rs
+++ b/src/git/cmd.rs
@@ -11,15 +11,18 @@ pub async fn git_cmd(cmd: &mut Command) -> Result<String, errors::Error> {
     let cmd = cmd.stderr(Stdio::piped());
 
     let child = cmd.stdout(Stdio::piped()).spawn().map_err(|err| errors::user_with_internal(
-        "Could not run git, which is a dependency of Git-Tool.",
-        "Please ensure that git is installed, present on your $PATH and executable before running Git-Tool again.",
+        "Failed to run git, which is a dependency of Git-Tool.",
+        "Please ensure that git is installed, available in your $PATH, and that Git-Tool has permission to execute it. Also check that the folder you are running git in exists, and that git has permission to access it.",
         err
     ))?;
-    let output = child.wait_with_output().await.map_err(|err| errors::user_with_internal(
-        "Could not run git, which is a dependency of Git-Tool.",
-        "Please ensure that git is installed, present on your $PATH and executable before running Git-Tool again.",
-        err
-    ))?;
+
+    let output = child.wait_with_output().await.map_err(|err| {
+        errors::user_with_internal(
+            "Git was started, but Git-Tool failed to retrieve its output.",
+            "This may indicate an issue with system resources or git crashing during execution.",
+            err,
+        )
+    })?;
 
     let output_text = String::from_utf8(output.stdout)?;
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -26,6 +26,7 @@ pub use commit::git_commit;
 #[allow(unused_imports)]
 pub use fetch::git_fetch;
 pub use init::git_init;
+#[allow(unused_imports)]
 pub use remote::{
     git_remote_add, git_remote_get_url, git_remote_list, git_remote_rename, git_remote_set_url,
 };

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -26,7 +26,9 @@ pub use commit::git_commit;
 #[allow(unused_imports)]
 pub use fetch::git_fetch;
 pub use init::git_init;
-pub use remote::{git_remote_add, git_remote_list, git_remote_set_url};
+pub use remote::{
+    git_remote_add, git_remote_get_url, git_remote_list, git_remote_rename, git_remote_set_url,
+};
 pub use switch::git_switch;
 
 #[cfg(test)]

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -17,6 +17,27 @@ pub async fn git_remote_list(repo: &path::Path) -> Result<Vec<String>, errors::E
     Ok(output)
 }
 
+pub async fn git_remote_get_url(
+    repo: &path::Path,
+    name: &str,
+) -> Result<Vec<String>, errors::Error> {
+    info!("Running `git remote get-url` to list configured remote url");
+    validate_repo_path_exists(repo)?;
+    let output = git_cmd(
+        Command::new("git")
+            .current_dir(repo)
+            .arg("remote")
+            .arg("get-url")
+            .arg(name),
+    )
+    .await?
+    .split_terminator('\n')
+    .map(|s| s.trim().to_string())
+    .collect();
+
+    Ok(output)
+}
+
 pub async fn git_remote_add(repo: &path::Path, name: &str, url: &str) -> Result<(), errors::Error> {
     info!("Running `git remote add $NAME $URL` to add new remote");
     validate_repo_path_exists(repo)?;
@@ -53,6 +74,25 @@ pub async fn git_remote_set_url(
     Ok(())
 }
 
+pub async fn git_remote_rename(
+    repo: &path::Path,
+    name: &str,
+    new_name: &str,
+) -> Result<(), errors::Error> {
+    info!("Running `git remote rename $NAME $NEW_NAME` to rename remote");
+    validate_repo_path_exists(repo)?;
+    git_cmd(
+        Command::new("git")
+            .current_dir(repo)
+            .arg("remote")
+            .arg("rename")
+            .arg(name)
+            .arg(new_name),
+    )
+        .await?;
+
+    Ok(())
+}
 #[cfg(test)]
 mod tests {
     use crate::git::*;

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -74,6 +74,7 @@ pub async fn git_remote_set_url(
     Ok(())
 }
 
+#[allow(dead_code)]
 pub async fn git_remote_rename(
     repo: &path::Path,
     name: &str,

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -89,7 +89,7 @@ pub async fn git_remote_rename(
             .arg(name)
             .arg(new_name),
     )
-        .await?;
+    .await?;
 
     Ok(())
 }

--- a/src/tasks/git_move_upstream.rs
+++ b/src/tasks/git_move_upstream.rs
@@ -1,0 +1,195 @@
+use crate::core::{Core, Repo, Target};
+use crate::errors;
+use crate::git::{git_remote_get_url, git_remote_list, git_remote_set_url};
+use crate::tasks::Task;
+use tracing_batteries::prelude::tracing;
+
+pub struct GitMoveUpstream {
+    pub new_repo: Repo,
+}
+
+#[async_trait::async_trait]
+impl Task for GitMoveUpstream {
+    #[tracing::instrument(name = "task:git_fix_upstream(repo)", err, skip(self, core))]
+    async fn apply_repo(
+        &self,
+        core: &Core,
+        repo: &crate::core::Repo,
+    ) -> Result<(), crate::core::Error> {
+        if !repo.exists() {
+            return Err(errors::user(
+                    &format!("The repository '{}' does not exist on your machine and cannot be moved as a result.", repo.name),
+                    &format!("Make sure the name is correct and that the repository exists by running `git-tool clone {}` first.", repo.name),
+                ));
+        }
+
+        let config = core.config();
+        let service = config.get_service(&repo.service).ok_or_else(|| {
+                errors::user(
+                    &format!("Could not find a service entry in your config file for '{}'", repo.service),
+                    &format!("Ensure that your git-tool configuration has a service entry for this service, or add it with `git-tool config add service/{}`", repo.service),
+                )
+            })?;
+
+        let expected_url = service.get_git_url(repo)?;
+        let new_url = service.get_git_url(&self.new_repo)?;
+
+        let remotes = git_remote_list(&repo.path).await?;
+        for remote in &remotes {
+            let urls = git_remote_get_url(&repo.path, remote).await?;
+            if urls.iter().any(|url| url == &expected_url) {
+                git_remote_set_url(&repo.get_path(), remote, &new_url).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tracing::instrument(name = "task:git_rename(scratchpad)", err, skip(self, _core))]
+    async fn apply_scratchpad(
+        &self,
+        _core: &Core,
+        _scratch: &crate::core::Scratchpad,
+    ) -> Result<(), crate::core::Error> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::Core;
+    use crate::git::{git_remote_add, git_remote_rename};
+    use crate::tasks::GitClone;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn move_upstream_errors_if_repo_does_not_exist() {
+        let temp = tempdir().unwrap();
+        let core = Core::builder()
+            .with_config_for_dev_directory(temp.path())
+            .with_null_console()
+            .build();
+
+        let repo = core
+            .resolver()
+            .get_best_repo("gh:git-fixtures/basic")
+            .unwrap();
+
+        let new_repo = core
+            .resolver()
+            .get_best_repo("gh:git-fixtures/renamed")
+            .unwrap();
+
+        let task = GitMoveUpstream {
+            new_repo: new_repo.clone(),
+        };
+
+        let result = task.apply_repo(&core, &repo).await;
+        assert!(result.is_err());
+        let err_msg = format!("{result:?}");
+        assert!(
+            err_msg.contains("does not exist"),
+            "Unexpected error message: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn move_upstream_updates_singular_remote() {
+        let temp = tempdir().unwrap();
+        let core = Core::builder()
+            .with_config_for_dev_directory(temp.path())
+            .with_null_console()
+            .build();
+
+        let repo = core
+            .resolver()
+            .get_best_repo("gh:git-fixtures/basic")
+            .unwrap();
+
+        let new_repo = core
+            .resolver()
+            .get_best_repo("gh:git-fixtures/renamed")
+            .unwrap();
+
+        GitClone {}.apply_repo(&core, &repo).await.unwrap();
+
+        let task = GitMoveUpstream {
+            new_repo: new_repo.clone(),
+        };
+
+        let result = task.apply_repo(&core, &repo).await;
+
+        assert!(result.is_ok());
+
+        let remotes = crate::git::git_remote_list(&repo.path).await.unwrap();
+        for remote in remotes {
+            let urls = crate::git::git_remote_get_url(&repo.path, &remote)
+                .await
+                .unwrap();
+            assert!(
+                urls.iter().any(|u| u.contains("git-fixtures/renamed")),
+                "Remote was not updated to point to new repo"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn move_upstream_updates_forked_remote() {
+        let temp = tempdir().unwrap();
+        let core = Core::builder()
+            .with_config_for_dev_directory(temp.path())
+            .with_null_console()
+            .build();
+
+        let repo = core
+            .resolver()
+            .get_best_repo("gh:git-fixtures/basic")
+            .unwrap();
+
+        let new_repo = core
+            .resolver()
+            .get_best_repo("gh:git-fixtures/renamed")
+            .unwrap();
+
+        GitClone {}.apply_repo(&core, &repo).await.unwrap();
+
+        // Simulate having a (forked) repository where the origin is our fork, and the original remote
+        // is in upstream
+        assert!(git_remote_rename(&repo.path, "origin", "upstream")
+            .await
+            .is_ok());
+        assert!(git_remote_add(
+            &repo.path,
+            "origin",
+            "git@github.com:sierrasoftworks/basic-git-fixtures.git"
+        )
+        .await
+        .is_ok());
+
+        let task = GitMoveUpstream {
+            new_repo: new_repo.clone(),
+        };
+
+        let result = task.apply_repo(&core, &repo).await;
+
+        assert!(result.is_ok());
+
+        let urls = crate::git::git_remote_get_url(&repo.path, "origin")
+            .await
+            .unwrap();
+        assert!(
+            urls.iter()
+                .any(|u| u.contains("sierrasoftworks/basic-git-fixtures")),
+            "origin shall point to our forked repository URL"
+        );
+
+        let urls = crate::git::git_remote_get_url(&repo.path, "upstream")
+            .await
+            .unwrap();
+        assert!(
+            urls.iter().any(|u| u.contains("git-fixtures/renamed")),
+            "upstream shall point to our updated repository URL"
+        );
+    }
+}

--- a/src/tasks/git_move_upstream.rs
+++ b/src/tasks/git_move_upstream.rs
@@ -60,7 +60,7 @@ mod tests {
     use super::*;
     use crate::core::Core;
     use crate::git::{git_remote_add, git_remote_rename};
-    use crate::tasks::GitClone;
+    use crate::tasks::{GitInit, GitRemote};
     use tempfile::tempdir;
 
     #[tokio::test]
@@ -112,7 +112,10 @@ mod tests {
             .get_best_repo("gh:git-fixtures/renamed")
             .unwrap();
 
-        GitClone {}.apply_repo(&core, &repo).await.unwrap();
+        sequence!(GitInit {}, GitRemote { name: "origin" })
+            .apply_repo(&core, &repo)
+            .await
+            .unwrap();
 
         let task = GitMoveUpstream {
             new_repo: new_repo.clone(),
@@ -152,7 +155,10 @@ mod tests {
             .get_best_repo("gh:git-fixtures/renamed")
             .unwrap();
 
-        GitClone {}.apply_repo(&core, &repo).await.unwrap();
+        sequence!(GitInit {}, GitRemote { name: "origin" })
+            .apply_repo(&core, &repo)
+            .await
+            .unwrap();
 
         // Simulate having a (forked) repository where the origin is our fork, and the original remote
         // is in upstream

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -25,8 +25,10 @@ mod git_checkout;
 mod git_clone;
 mod git_commit;
 mod git_init;
+mod git_move_upstream;
 mod git_remote;
 mod git_switch;
+mod move_directory;
 mod new_folder;
 mod write_file;
 
@@ -39,8 +41,10 @@ pub use git_clone::GitClone;
 #[allow(unused_imports)]
 pub use git_commit::GitCommit;
 pub use git_init::GitInit;
+pub use git_move_upstream::GitMoveUpstream;
 pub use git_remote::GitRemote;
 pub use git_switch::GitSwitch;
+pub use move_directory::MoveDirectory;
 pub use new_folder::NewFolder;
 pub use sequence::Sequence;
 #[allow(unused_imports)]

--- a/src/tasks/move_directory.rs
+++ b/src/tasks/move_directory.rs
@@ -139,4 +139,39 @@ mod tests {
             "Unexpected error message: {msg}"
         );
     }
+
+    #[tokio::test]
+    async fn test_scratch() {
+        let temp = tempdir().unwrap();
+        let scratch = crate::core::Scratchpad::new("2019w15", temp.path().join("scratch"));
+        let new_scratch = temp.path().join("new_scratch");
+
+        let core = Core::builder()
+            .with_config_for_dev_directory(temp.path())
+            .build();
+
+        assert!(
+            fs::create_dir(scratch.get_path()).is_ok(),
+            "scratchpad directory should be created"
+        );
+
+        assert!(scratch.exists());
+        assert!(!new_scratch.clone().exists());
+
+        MoveDirectory {
+            new_path: new_scratch.clone(),
+        }
+        .apply_scratchpad(&core, &scratch)
+        .await
+        .unwrap();
+
+        assert!(
+            !scratch.get_path().exists(),
+            "old scratchpad should no longer exist."
+        );
+        assert!(
+            new_scratch.exists(),
+            "scratchpad should be moved to new directory"
+        );
+    }
 }

--- a/src/tasks/move_directory.rs
+++ b/src/tasks/move_directory.rs
@@ -42,8 +42,27 @@ impl Task for MoveDirectory {
     async fn apply_scratchpad(
         &self,
         _core: &Core,
-        _scratch: &crate::core::Scratchpad,
+        scratch: &crate::core::Scratchpad,
     ) -> Result<(), crate::core::Error> {
+        if !scratch.exists() {
+            return Err(errors::user(
+                format!("The scratchpad {} does not exist on your machine and cannot be moved as a result.", scratch.get_name()).as_str(),
+                "Make sure the name is correct and that the scratchpad exists first."
+            ));
+        }
+
+        fs::rename(scratch.get_path(), self.new_path.clone()).map_err(|err| {
+            errors::user_with_internal(
+                &format!(
+                    "Could not rename the scratchpad directory '{}' to '{}' due to an OS-level error.",
+                    scratch.get_path().display(),
+                    self.new_path.display()
+                ),
+                "Check that Git-Tool has permission to create this directory and any missing parent directories.",
+                err,
+            )
+        })?;
+
         Ok(())
     }
 }

--- a/src/tasks/move_directory.rs
+++ b/src/tasks/move_directory.rs
@@ -1,0 +1,123 @@
+use crate::core::{Core, Target};
+use crate::errors;
+use crate::tasks::Task;
+use std::{fs, path};
+use tracing_batteries::prelude::tracing;
+
+pub struct MoveDirectory {
+    pub new_path: path::PathBuf,
+}
+
+#[async_trait::async_trait]
+impl Task for MoveDirectory {
+    #[tracing::instrument(name = "task:move_directory(repo)", err, skip(self, _core))]
+    async fn apply_repo(
+        &self,
+        _core: &Core,
+        repo: &crate::core::Repo,
+    ) -> Result<(), crate::core::Error> {
+        if !repo.exists() {
+            return Err(errors::user(
+                format!("The repository {} does not exist on your machine and cannot be moved as a result.", repo.name).as_str(),
+                format!("Make sure the name is correct and that the repository exists by running `git-tool clone {}` first.", repo.name).as_str()
+            ));
+        }
+
+        fs::rename(repo.path.clone(), self.new_path.clone()).map_err(|err| {
+            errors::user_with_internal(
+                &format!(
+                    "Could not rename the repository directory '{}' to '{}' due to an OS-level error.",
+                    repo.path.display(),
+                    self.new_path.display()
+                ),
+                "Check that Git-Tool has permission to create this directory and any missing parent directories.",
+                err,
+            )
+        })?;
+
+        Ok(())
+    }
+
+    #[tracing::instrument(name = "task:git_rename(scratchpad)", err, skip(self, _core))]
+    async fn apply_scratchpad(
+        &self,
+        _core: &Core,
+        _scratch: &crate::core::Scratchpad,
+    ) -> Result<(), crate::core::Error> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tasks::GitClone;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn move_directory_successfully() {
+        let temp = tempdir().unwrap();
+        let repo = crate::core::Repo::new(
+            "gh:sierrasoftworks/git-tool",
+            temp.path().join("original_repo"),
+        );
+
+        let new_repo =
+            crate::core::Repo::new("gh:sierrasoftworks/gt", temp.path().join("new_repo"));
+
+        let core = Core::builder()
+            .with_config_for_dev_directory(temp.path())
+            .with_null_console()
+            .build();
+
+        GitClone {}.apply_repo(&core, &repo).await.unwrap();
+
+        assert!(repo.path.exists());
+        assert!(repo.valid());
+
+        MoveDirectory {
+            new_path: new_repo.path.clone(),
+        }
+        .apply_repo(&core, &repo)
+        .await
+        .unwrap();
+
+        assert!(!repo.valid());
+        assert!(!repo.path.exists());
+        assert!(new_repo.valid());
+        assert!(new_repo.path.exists());
+    }
+
+    #[tokio::test]
+    async fn move_directory_no_repository_to_rename() {
+        let temp = tempdir().unwrap();
+
+        let repo = crate::core::Repo::new(
+            "gh:sierrasoftworks/git-tool",
+            temp.path().join("non_existent_repo"),
+        );
+
+        let new_repo =
+            crate::core::Repo::new("gh:sierrasoftworks/gt", temp.path().join("new_repo"));
+
+        let core = Core::builder()
+            .with_config_for_dev_directory(temp.path())
+            .with_null_console()
+            .build();
+
+        let result = MoveDirectory {
+            new_path: new_repo.path.clone(),
+        }
+        .apply_repo(&core, &repo)
+        .await;
+
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("does not exist on your machine and cannot be moved as a result."),
+            "Unexpected error message: {msg}"
+        );
+    }
+}


### PR DESCRIPTION
this PR adds the functionality to rename git repositories and automatically change the upstream URL.

For example, given a repository layout of

```
~/
└ src/
  └ gh/
    └ SierraSoftworks/
      └ git-tool (origin git@github.com:SierraSoftworks/git-tool.git)
```

running

```bash
gt mv gh:SierraSoftworks/git-tool gh:SierraSoftworks/gt
```

will result in

```
~/
└ src/
  └ gh/
    └ SierraSoftworks/
      └ gt (origin git@github.com:SierraSoftworks/gt.git)
```

However, if you wish to only update the repository locally, you can specify `--no-update-remote`:

```bash
gt mv gh:SierraSoftworks/git-tool gh:SierraSoftworks/gt
```

will result in

```
~/
└ src/
  └ gh/
    └ SierraSoftworks/
      └ gt (origin git@github.com:SierraSoftworks/git-tool.git)
```

leaving the `origin` URL in tact