### PR TITLE
feat: Improve handling of missing git repo directory

### DIFF
--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -137,6 +137,7 @@ features:
         .unwrap();
 
         let temp = tempdir().unwrap();
+        std::fs::create_dir(temp.path().join("repo")).expect("create test repo dir");
 
         let temp_path = temp.path().to_path_buf();
         let core = Core::builder()
@@ -169,6 +170,7 @@ features:
         let cmd = CloneCommand {};
 
         let temp = tempdir().unwrap();
+        std::fs::create_dir(temp.path().join("repo")).expect("create test repo dir");
 
         let args = cmd.app().get_matches_from(vec![
             "clone",

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -105,7 +105,7 @@ impl CompleteCommand {
             }
             None => {
                 for cmd in inventory::iter::<Command> {
-                    completer.offer(&cmd.name());
+                    completer.offer(cmd.name());
                 }
             }
         }

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -126,6 +126,8 @@ mod tests {
             .get_matches_from(vec!["new", "test/new-repo-partial"]);
 
         let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("gh").join("test").join("new-repo-partial"))
+            .expect("create test repo dir");
 
         let core = Core::builder()
             .with_config_for_dev_directory(temp.path())
@@ -159,6 +161,8 @@ mod tests {
             .get_matches_from(vec!["new", "gh:test/new-repo-full"]);
 
         let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("gh").join("test").join("new-repo-full"))
+            .expect("create test repo dir");
 
         let core = Core::builder()
             .with_config_for_dev_directory(temp.path())

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -197,6 +197,7 @@ features:
         .unwrap();
 
         let temp = tempdir().unwrap();
+        std::fs::create_dir(temp.path().join("repo")).expect("create test repo dir");
         let temp_path = temp.path().to_owned();
         let core = Core::builder()
             .with_config(cfg)

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -141,6 +141,7 @@ mod tests {
         );
 
         let repo_path = repo.get_path();
+        std::fs::create_dir_all(&repo_path).expect("create test repo dir");
         let core = core
             .with_mock_resolver(|mock| {
                 let repo_path = repo_path.clone();

--- a/src/core/templates.rs
+++ b/src/core/templates.rs
@@ -50,7 +50,7 @@ struct RepoWithService<'a> {
 }
 
 #[allow(clippy::from_over_into)]
-impl<'a> Into<Value> for RepoWithService<'a> {
+impl Into<Value> for RepoWithService<'_> {
     fn into(self) -> Value {
         let service: Value = self.service.into();
 

--- a/src/git/add.rs
+++ b/src/git/add.rs
@@ -1,9 +1,9 @@
 use super::git_cmd;
 use crate::errors;
+use crate::git::cmd::validate_repo_path_exists;
 use std::path;
 use tokio::process::Command;
 use tracing_batteries::prelude::*;
-use crate::git::cmd::validate_repo_path_exists;
 
 pub async fn git_add(repo: &path::Path, paths: &Vec<&str>) -> Result<(), errors::Error> {
     info!("Running `git add` to add files to the index");

--- a/src/git/add.rs
+++ b/src/git/add.rs
@@ -3,9 +3,11 @@ use crate::errors;
 use std::path;
 use tokio::process::Command;
 use tracing_batteries::prelude::*;
+use crate::git::cmd::validate_repo_path_exists;
 
 pub async fn git_add(repo: &path::Path, paths: &Vec<&str>) -> Result<(), errors::Error> {
     info!("Running `git add` to add files to the index");
+    validate_repo_path_exists(repo)?;
     git_cmd(Command::new("git").current_dir(repo).arg("add").args(paths)).await?;
 
     Ok(())

--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -1,5 +1,6 @@
 use super::git_cmd;
 use crate::errors;
+use crate::git::cmd::validate_repo_path_exists;
 use itertools::intersperse;
 use std::{collections::HashSet, path};
 use tokio::process::Command;
@@ -8,6 +9,7 @@ use tracing_batteries::prelude::*;
 #[allow(dead_code)]
 pub async fn git_current_branch(repo: &path::Path) -> Result<String, errors::Error> {
     info!("Running `git symbolic-ref --short -q HEAD` to get the current branch name");
+    validate_repo_path_exists(repo)?;
     Ok(git_cmd(
         Command::new("git")
             .current_dir(repo)
@@ -23,6 +25,7 @@ pub async fn git_current_branch(repo: &path::Path) -> Result<String, errors::Err
 
 pub async fn git_branches(repo: &path::Path) -> Result<Vec<String>, errors::Error> {
     info!("Running `git for-each-ref --format=%(refname:lstrip=2) refs/heads/` to get the list of branches");
+    validate_repo_path_exists(repo)?;
     let output = git_cmd(
         Command::new("git")
             .current_dir(repo)
@@ -53,6 +56,7 @@ pub async fn git_branches(repo: &path::Path) -> Result<Vec<String>, errors::Erro
 
 pub async fn git_branch_delete(repo: &path::Path, name: &str) -> Result<(), errors::Error> {
     info!("Running `git branch -D $NAME` to delete branch");
+    validate_repo_path_exists(repo)?;
     git_cmd(
         Command::new("git")
             .current_dir(repo)
@@ -67,6 +71,7 @@ pub async fn git_branch_delete(repo: &path::Path, name: &str) -> Result<(), erro
 
 pub async fn git_default_branch(repo: &path::Path) -> Result<String, errors::Error> {
     info!("Running `git symbolic-ref refs/remotes/origin/HEAD` to get the default branch");
+    validate_repo_path_exists(repo)?;
     Ok(intersperse(
         git_cmd(
             Command::new("git")
@@ -85,6 +90,7 @@ pub async fn git_default_branch(repo: &path::Path) -> Result<String, errors::Err
 
 pub async fn git_merged_branches(repo: &path::Path) -> Result<Vec<String>, errors::Error> {
     info!("Running `git branch --merged` to get the list of merged branches");
+    validate_repo_path_exists(repo)?;
     let output = git_cmd(
         Command::new("git")
             .current_dir(repo)

--- a/src/git/checkout.rs
+++ b/src/git/checkout.rs
@@ -1,11 +1,13 @@
 use super::git_cmd;
 use crate::errors;
+use crate::git::cmd::validate_repo_path_exists;
 use std::path;
 use tokio::process::Command;
 use tracing_batteries::prelude::*;
 
 pub async fn git_checkout(repo: &path::Path, name: &str) -> Result<(), errors::Error> {
     info!("Running `git checkout -B $BRANCH_NAME` to switch branches");
+    validate_repo_path_exists(repo)?;
     git_cmd(
         Command::new("git")
             .current_dir(repo)

--- a/src/git/clone.rs
+++ b/src/git/clone.rs
@@ -7,7 +7,6 @@ use tracing_batteries::prelude::*;
 
 pub async fn git_clone(repo: &path::Path, url: &str) -> Result<(), errors::Error> {
     info!("Running `git clone --recurse-submodules $URL` to prepare repository");
-    validate_repo_path_exists(repo)?;
     git_cmd(
         Command::new("git")
             .arg("clone")

--- a/src/git/clone.rs
+++ b/src/git/clone.rs
@@ -1,11 +1,13 @@
 use super::git_cmd;
 use crate::errors;
+use crate::git::cmd::validate_repo_path_exists;
 use std::path;
 use tokio::process::Command;
 use tracing_batteries::prelude::*;
 
 pub async fn git_clone(repo: &path::Path, url: &str) -> Result<(), errors::Error> {
     info!("Running `git clone --recurse-submodules $URL` to prepare repository");
+    validate_repo_path_exists(repo)?;
     git_cmd(
         Command::new("git")
             .arg("clone")

--- a/src/git/clone.rs
+++ b/src/git/clone.rs
@@ -1,6 +1,5 @@
 use super::git_cmd;
 use crate::errors;
-use crate::git::cmd::validate_repo_path_exists;
 use std::path;
 use tokio::process::Command;
 use tracing_batteries::prelude::*;

--- a/src/git/cmd.rs
+++ b/src/git/cmd.rs
@@ -1,4 +1,5 @@
 use crate::errors;
+use std::path::Path;
 use std::process::Stdio;
 use tokio::process::Command;
 use tracing_batteries::prelude::*;
@@ -45,5 +46,16 @@ pub async fn git_cmd(cmd: &mut Command) -> Result<String, errors::Error> {
         }
     } else {
         Ok(output_text)
+    }
+}
+
+pub fn validate_repo_path_exists(repo: &Path) -> Result<(), errors::Error> {
+    if !repo.exists() {
+        Err(errors::user(
+            &format!("The repository path '{}' does not exist.", repo.display()),
+            "Please check that the path is correct and that you have permission to access it.",
+        ))
+    } else {
+        Ok(())
     }
 }

--- a/src/git/commit.rs
+++ b/src/git/commit.rs
@@ -1,5 +1,6 @@
 use super::git_cmd;
 use crate::errors;
+use crate::git::cmd::validate_repo_path_exists;
 use std::path;
 use tokio::process::Command;
 use tracing_batteries::prelude::*;
@@ -10,6 +11,7 @@ pub async fn git_commit(
     paths: &Vec<&str>,
 ) -> Result<(), errors::Error> {
     info!("Running `git commit` to create a new commit for specific files");
+    validate_repo_path_exists(repo)?;
     git_cmd(
         Command::new("git")
             .current_dir(repo)

--- a/src/git/config.rs
+++ b/src/git/config.rs
@@ -3,6 +3,7 @@ use std::path;
 use tokio::process::Command;
 use tracing_batteries::prelude::*;
 
+use crate::git::cmd::validate_repo_path_exists;
 use crate::{errors, git::git_cmd};
 
 pub async fn git_config_set(
@@ -11,6 +12,7 @@ pub async fn git_config_set(
     value: &str,
 ) -> Result<(), errors::Error> {
     info!("Running `git config` to set a configuration value");
+    validate_repo_path_exists(repo)?;
     git_cmd(
         Command::new("git")
             .current_dir(repo)

--- a/src/git/fetch.rs
+++ b/src/git/fetch.rs
@@ -1,5 +1,6 @@
 use super::git_cmd;
 use crate::errors;
+use crate::git::cmd::validate_repo_path_exists;
 use std::path;
 use tokio::process::Command;
 use tracing_batteries::prelude::*;
@@ -7,6 +8,7 @@ use tracing_batteries::prelude::*;
 #[allow(dead_code)]
 pub async fn git_fetch(repo: &path::Path, origin: &str) -> Result<(), errors::Error> {
     info!("Running `git fetch $ORIGIN`");
+    validate_repo_path_exists(repo)?;
     git_cmd(
         Command::new("git")
             .current_dir(repo)

--- a/src/git/init.rs
+++ b/src/git/init.rs
@@ -10,3 +10,22 @@ pub async fn git_init(path: &path::Path) -> Result<(), errors::Error> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_git_init() {
+        let temp_dir = tempfile::tempdir().expect("a temporary directory");
+
+        git_init(temp_dir.path())
+            .await
+            .expect("git init to succeed");
+
+        assert!(
+            temp_dir.path().join(".git").exists(),
+            "git init to create .git directory"
+        );
+    }
+}

--- a/src/git/init.rs
+++ b/src/git/init.rs
@@ -7,7 +7,6 @@ use tracing_batteries::prelude::*;
 
 pub async fn git_init(path: &path::Path) -> Result<(), errors::Error> {
     info!("Running `git init` to prepare repository");
-    validate_repo_path_exists(path)?;
     git_cmd(Command::new("git").arg("init").arg(path)).await?;
 
     Ok(())

--- a/src/git/init.rs
+++ b/src/git/init.rs
@@ -1,6 +1,5 @@
 use super::git_cmd;
 use crate::errors;
-use crate::git::cmd::validate_repo_path_exists;
 use std::path;
 use tokio::process::Command;
 use tracing_batteries::prelude::*;

--- a/src/git/init.rs
+++ b/src/git/init.rs
@@ -1,11 +1,13 @@
 use super::git_cmd;
 use crate::errors;
+use crate::git::cmd::validate_repo_path_exists;
 use std::path;
 use tokio::process::Command;
 use tracing_batteries::prelude::*;
 
 pub async fn git_init(path: &path::Path) -> Result<(), errors::Error> {
     info!("Running `git init` to prepare repository");
+    validate_repo_path_exists(path)?;
     git_cmd(Command::new("git").arg("init").arg(path)).await?;
 
     Ok(())

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -1,11 +1,13 @@
 use super::git_cmd;
 use crate::errors;
+use crate::git::cmd::validate_repo_path_exists;
 use std::path;
 use tokio::process::Command;
 use tracing_batteries::prelude::*;
 
 pub async fn git_rev_parse(repo: &path::Path, ref_name: &str) -> Result<String, errors::Error> {
     info!("Running `git rev-parse --verify` to get the SHA of a specific reference");
+    validate_repo_path_exists(repo)?;
     Ok(git_cmd(
         Command::new("git")
             .current_dir(repo)
@@ -24,6 +26,7 @@ pub async fn git_update_ref(
     sha: &str,
 ) -> Result<(), errors::Error> {
     info!("Running `git update-ref` to update a reference to point at a specific commit");
+    validate_repo_path_exists(repo)?;
     git_cmd(
         Command::new("git")
             .current_dir(repo)

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -48,3 +48,27 @@ pub async fn git_remote_set_url(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::git::*;
+    
+    #[tokio::test]
+    async fn test_git_remote() {
+        let temp_dir = tempfile::tempdir().expect("a temporary directory");
+        
+        git_init(temp_dir.path()).await.expect("git init to succeed");
+        
+        let remotes = git_remote_list(temp_dir.path()).await.expect("git init to succeed");
+        assert_eq!(remotes.len(), 0, "git remote list should be empty");
+        
+        git_remote_add(temp_dir.path(), "origin", "https://example.com/test.git").await.expect("git remote add origin https://example.com/test.git to succeed");
+        let remotes = git_remote_list(temp_dir.path()).await.expect("git remote list to succeed");
+        assert_eq!(remotes, vec!["origin"], "git remote list should have one remote: [origin]");
+        
+        git_remote_set_url(temp_dir.path(), "origin", "https://example.com/test2.git").await.expect("git remote set-url origin https://example.com/test2.git to succeed");
+        let remotes = git_remote_list(temp_dir.path()).await.expect("git remote list to succeed");
+        assert_eq!(remotes, vec!["origin"], "git remote list should have one remote: [origin]");
+    }
+    
+}

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -1,11 +1,13 @@
 use super::git_cmd;
 use crate::errors;
+use crate::git::cmd::validate_repo_path_exists;
 use std::path;
 use tokio::process::Command;
 use tracing_batteries::prelude::*;
 
 pub async fn git_remote_list(repo: &path::Path) -> Result<Vec<String>, errors::Error> {
     info!("Running `git remote` to list configured remotes");
+    validate_repo_path_exists(repo)?;
     let output = git_cmd(Command::new("git").current_dir(repo).arg("remote"))
         .await?
         .split_terminator('\n')
@@ -17,6 +19,7 @@ pub async fn git_remote_list(repo: &path::Path) -> Result<Vec<String>, errors::E
 
 pub async fn git_remote_add(repo: &path::Path, name: &str, url: &str) -> Result<(), errors::Error> {
     info!("Running `git remote add $NAME $URL` to add new remote");
+    validate_repo_path_exists(repo)?;
     git_cmd(
         Command::new("git")
             .current_dir(repo)
@@ -36,6 +39,7 @@ pub async fn git_remote_set_url(
     url: &str,
 ) -> Result<(), errors::Error> {
     info!("Running `git remote set-url $NAME $URL` to add new remote");
+    validate_repo_path_exists(repo)?;
     git_cmd(
         Command::new("git")
             .current_dir(repo)
@@ -52,23 +56,42 @@ pub async fn git_remote_set_url(
 #[cfg(test)]
 mod tests {
     use crate::git::*;
-    
+
     #[tokio::test]
     async fn test_git_remote() {
         let temp_dir = tempfile::tempdir().expect("a temporary directory");
-        
-        git_init(temp_dir.path()).await.expect("git init to succeed");
-        
-        let remotes = git_remote_list(temp_dir.path()).await.expect("git init to succeed");
+
+        git_init(temp_dir.path())
+            .await
+            .expect("git init to succeed");
+
+        let remotes = git_remote_list(temp_dir.path())
+            .await
+            .expect("git init to succeed");
         assert_eq!(remotes.len(), 0, "git remote list should be empty");
-        
-        git_remote_add(temp_dir.path(), "origin", "https://example.com/test.git").await.expect("git remote add origin https://example.com/test.git to succeed");
-        let remotes = git_remote_list(temp_dir.path()).await.expect("git remote list to succeed");
-        assert_eq!(remotes, vec!["origin"], "git remote list should have one remote: [origin]");
-        
-        git_remote_set_url(temp_dir.path(), "origin", "https://example.com/test2.git").await.expect("git remote set-url origin https://example.com/test2.git to succeed");
-        let remotes = git_remote_list(temp_dir.path()).await.expect("git remote list to succeed");
-        assert_eq!(remotes, vec!["origin"], "git remote list should have one remote: [origin]");
+
+        git_remote_add(temp_dir.path(), "origin", "https://example.com/test.git")
+            .await
+            .expect("git remote add origin https://example.com/test.git to succeed");
+        let remotes = git_remote_list(temp_dir.path())
+            .await
+            .expect("git remote list to succeed");
+        assert_eq!(
+            remotes,
+            vec!["origin"],
+            "git remote list should have one remote: [origin]"
+        );
+
+        git_remote_set_url(temp_dir.path(), "origin", "https://example.com/test2.git")
+            .await
+            .expect("git remote set-url origin https://example.com/test2.git to succeed");
+        let remotes = git_remote_list(temp_dir.path())
+            .await
+            .expect("git remote list to succeed");
+        assert_eq!(
+            remotes,
+            vec!["origin"],
+            "git remote list should have one remote: [origin]"
+        );
     }
-    
 }

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -67,7 +67,7 @@ mod tests {
 
         let remotes = git_remote_list(temp_dir.path())
             .await
-            .expect("git init to succeed");
+            .expect("git remote list to succeed");
         assert_eq!(remotes.len(), 0, "git remote list should be empty");
 
         git_remote_add(temp_dir.path(), "origin", "https://example.com/test.git")

--- a/src/git/switch.rs
+++ b/src/git/switch.rs
@@ -2,9 +2,13 @@ use tokio::process::Command;
 
 use super::git_cmd;
 use crate::errors;
+use crate::git::cmd::validate_repo_path_exists;
 use std::path;
+use tracing_batteries::prelude::*;
 
 pub async fn git_switch(repo: &path::Path, name: &str, create: bool) -> Result<(), errors::Error> {
+    info!("Running `git switch $BRANCH_NAME` to switch branches");
+    validate_repo_path_exists(repo)?;
     if create {
         git_cmd(
             Command::new("git")

--- a/src/tasks/git_add.rs
+++ b/src/tasks/git_add.rs
@@ -7,7 +7,7 @@ pub struct GitAdd<'a> {
 }
 
 #[async_trait::async_trait]
-impl<'a> Task for GitAdd<'a> {
+impl Task for GitAdd<'_> {
     #[tracing::instrument(name = "task:git_add(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &core::Repo) -> Result<(), core::Error> {
         git::git_add(&repo.get_path(), &self.paths).await

--- a/src/tasks/git_checkout.rs
+++ b/src/tasks/git_checkout.rs
@@ -7,7 +7,7 @@ pub struct GitCheckout<'a> {
 }
 
 #[async_trait::async_trait]
-impl<'a> Task for GitCheckout<'a> {
+impl Task for GitCheckout<'_> {
     #[tracing::instrument(name = "task:git_checkout(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &core::Repo) -> Result<(), core::Error> {
         git::git_checkout(&repo.get_path(), self.branch).await

--- a/src/tasks/git_commit.rs
+++ b/src/tasks/git_commit.rs
@@ -8,7 +8,7 @@ pub struct GitCommit<'a> {
 }
 
 #[async_trait::async_trait]
-impl<'a> Task for GitCommit<'a> {
+impl Task for GitCommit<'_> {
     #[tracing::instrument(name = "task:git_commit(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &core::Repo) -> Result<(), core::Error> {
         git::git_commit(&repo.get_path(), self.message, &self.paths).await

--- a/src/tasks/git_remote.rs
+++ b/src/tasks/git_remote.rs
@@ -13,7 +13,7 @@ impl Default for GitRemote<'static> {
 }
 
 #[async_trait::async_trait]
-impl<'a> Task for GitRemote<'a> {
+impl Task for GitRemote<'_> {
     #[tracing::instrument(name = "task:git_remote(repo)", err, skip(self, core))]
     async fn apply_repo(&self, core: &Core, repo: &core::Repo) -> Result<(), core::Error> {
         let service = core.config().get_service(&repo.service).ok_or_else(|| errors::user(

--- a/src/tasks/write_file.rs
+++ b/src/tasks/write_file.rs
@@ -10,7 +10,7 @@ pub struct WriteFile<'a> {
 }
 
 #[async_trait::async_trait]
-impl<'a> Task for WriteFile<'a> {
+impl Task for WriteFile<'_> {
     #[tracing::instrument(name = "task:write_file(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &core::Repo) -> Result<(), core::Error> {
         let path = repo.get_path().join(&self.path);


### PR DESCRIPTION
This PR adds logic to explicitly check the existence of a git repo directory before spawning a git command in said directory, allowing us to present better error messages to the user in these situations (instead of a generic `File not found (error code 2)` error).