### PR TITLE
feat(fork): implement repository forking functionality in `gt new`

### DIFF
--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -50,7 +50,7 @@ impl CommandRunnable for CloneCommand {
                 )
             })?;
 
-            let operation = sequence![GitClone {}];
+            let operation = sequence![GitClone::default()];
 
             for line in file.lines() {
                 if line.trim_start().is_empty() || line.trim_start().starts_with('#') {
@@ -69,7 +69,7 @@ impl CommandRunnable for CloneCommand {
             let repo = core.resolver().get_best_repo(&identifier)?;
 
             if !repo.exists() {
-                match sequence![GitClone {}].apply_repo(core, &repo).await {
+                match sequence![GitClone::default()].apply_repo(core, &repo).await {
                     Ok(()) => {}
                     Err(e) => return Err(e),
                 }

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -70,7 +70,7 @@ New applications can be configured either by making changes to your configuratio
         };
 
         if !repo.exists() {
-            match sequence![GitClone {}].apply_repo(core, &repo).await {
+            match sequence![GitClone::default()].apply_repo(core, &repo).await {
                 Ok(()) => {}
                 Err(_) if matches.get_flag("create") => {
                     sequence![

--- a/src/engine/features.rs
+++ b/src/engine/features.rs
@@ -5,6 +5,7 @@ pub const CREATE_REMOTE: &str = "create_remote";
 pub const CREATE_REMOTE_PRIVATE: &str = "create_remote_private";
 pub const CHECK_EXISTS: &str = "check_exists";
 pub const MOVE_REMOTE: &str = "move_remote";
+pub const FORK_REPOSITORY: &str = "fork_repository";
 
 pub const OPEN_NEW_REPO: &str = "open_new_repo_in_default_app";
 pub const ALWAYS_OPEN_BEST_MATCH: &str = "always_open_best_match";
@@ -18,6 +19,7 @@ lazy_static! {
         CREATE_REMOTE_PRIVATE,
         CHECK_EXISTS,
         MOVE_REMOTE,
+        FORK_REPOSITORY,
         OPEN_NEW_REPO,
         ALWAYS_OPEN_BEST_MATCH,
         TELEMETRY,

--- a/src/online/service/mod.rs
+++ b/src/online/service/mod.rs
@@ -24,6 +24,14 @@ pub trait OnlineService: Send + Sync {
         source: &Repo,
         destination: &Repo,
     ) -> Result<(), Error>;
+
+    async fn fork_repo(
+        &self,
+        core: &Core,
+        service: &Service,
+        source: &Repo,
+        destination: &Repo,
+    ) -> Result<(), Error>;
 }
 
 #[allow(dead_code)]

--- a/src/tasks/fork_repo.rs
+++ b/src/tasks/fork_repo.rs
@@ -1,0 +1,149 @@
+use super::*;
+use crate::engine::Repo;
+use tracing_batteries::prelude::*;
+
+pub struct ForkRepository {
+    pub from_repo: Repo,
+    pub no_create_remote: bool,
+}
+
+#[async_trait::async_trait]
+impl Task for ForkRepository {
+    #[cfg(feature = "auth")]
+    #[tracing::instrument(name = "task:fork_repository(repo)", err, skip(self, core))]
+    async fn apply_repo(&self, core: &Core, repo: &Repo) -> Result<(), engine::Error> {
+        let service = core.config().get_service(&repo.service)?;
+        let from_service = core.config().get_service(&self.from_repo.service)?;
+        let url = service.get_git_url(repo)?;
+        let from_url = from_service.get_git_url(&self.from_repo)?;
+        let mut supported_service = false;
+
+        // Forking a repository can come in two forms:
+        // 1. Using a supported Online Service Attempt to perform a fork/template instantiation using the API.
+        // 2. Clone the original repository in the new directory and update the origin URL
+        if core
+            .config()
+            .get_features()
+            .has(engine::features::MOVE_REMOTE)
+        {
+            let service = core.config().get_service(&repo.service)?;
+
+            if let Some(online_service) = crate::online::services()
+                .iter()
+                .find(|s| s.handles(service))
+            {
+                supported_service = true;
+                online_service
+                    .fork_repo(core, service, &self.from_repo, repo)
+                    .await?;
+            }
+        }
+
+        let tasks = sequence![
+            GitClone {
+                path: if supported_service {
+                    "".to_string()
+                } else {
+                    repo.path.to_str().unwrap().to_string()
+                }
+            },
+            GitAddRemote {
+                name: "origin".to_string(),
+                url,
+            },
+            GitAddRemote {
+                name: "upstream".to_string(),
+                url: from_url,
+            },
+            CreateRemote {
+                enabled: !self.no_create_remote
+            }
+        ];
+
+        tasks
+            .apply_repo(
+                core,
+                if supported_service {
+                    repo
+                } else {
+                    &self.from_repo
+                },
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::engine::{Core, Identifier, Repo};
+    use crate::tasks::{ForkRepository, Task};
+    use mockall::predicate::eq;
+    use rstest::rstest;
+    use tempfile::tempdir;
+
+    #[rstest]
+    #[tokio::test]
+    #[cfg(feature = "auth")]
+    #[case("gh:git-fixtures/basic", "git-fixtures/basic", "gh:cedi/basic")]
+    #[cfg_attr(feature = "pure-tests", ignore)]
+    async fn fork_repo(#[case] source_repo: &str, #[case] source: &str, #[case] target_repo: &str) {
+        let temp = tempdir().unwrap();
+        let temp_path = temp.path().to_path_buf();
+
+        let core = Core::builder()
+            .with_config_for_dev_directory(temp.path())
+            .with_mock_http_client(crate::online::service::github::mocks::repo_fork(source))
+            .with_mock_keychain(|mock| {
+                mock.expect_get_token()
+                    .with(eq("gh"))
+                    .returning(|_| Ok("test_token".into()));
+            })
+            .with_mock_resolver(|mock| {
+                let source_temp_path = temp_path.clone();
+                let source = source_repo.to_owned();
+                let source_identifier: Identifier = source.parse().unwrap();
+                mock.expect_get_best_repo()
+                    .with(eq(source_identifier))
+                    .times(1)
+                    .returning(move |_| {
+                        Ok(Repo::new(
+                            "gh:git-fixtures/basic",
+                            source_temp_path.join(&source),
+                        ))
+                    });
+
+                let target_temp_path = temp_path.clone();
+                let target = target_repo.to_owned();
+                let target_identifier: Identifier = target.parse().unwrap();
+                mock.expect_get_best_repo()
+                    .with(eq(target_identifier))
+                    .times(1)
+                    .returning(move |_| {
+                        Ok(Repo::new(
+                            "gh:git-fixtures/empty",
+                            target_temp_path.join(&target),
+                        ))
+                    });
+            })
+            .build();
+
+        let from_repo = core
+            .resolver()
+            .get_best_repo(&source_repo.parse().unwrap())
+            .unwrap();
+        let target_repo = core
+            .resolver()
+            .get_best_repo(&target_repo.parse().unwrap())
+            .unwrap();
+
+        ForkRepository {
+            from_repo,
+            no_create_remote: true,
+        }
+        .apply_repo(&core, &target_repo)
+        .await
+        .unwrap();
+    }
+}

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -20,6 +20,7 @@ macro_rules! sequence {
 
 mod create_remote;
 mod ensure_no_remote;
+mod fork_repo;
 mod git_add;
 mod git_checkout;
 mod git_clone;
@@ -34,6 +35,7 @@ mod write_file;
 
 pub use create_remote::CreateRemote;
 pub use ensure_no_remote::EnsureNoRemote;
+pub use fork_repo::ForkRepository;
 #[allow(unused_imports)]
 pub use git_add::GitAdd;
 pub use git_checkout::GitCheckout;
@@ -41,7 +43,7 @@ pub use git_clone::GitClone;
 #[allow(unused_imports)]
 pub use git_commit::GitCommit;
 pub use git_init::GitInit;
-pub use git_remote::GitRemote;
+pub use git_remote::{GitAddRemote, GitRemote};
 pub use git_switch::GitSwitch;
 pub use move_directory::MoveDirectory;
 pub use move_remote::MoveRemote;


### PR DESCRIPTION
- add 'from' argument to create a fork of an existing remote repository
- add fork_repo method to GitHubService for forking repositories
- create ForkRepository task to handle repository forking
- update GitClone to use default struct initialization
- implement GitAddRemote task for adding/removing git remotes
- add tests for ForkRepository and GitAddRemote functionalities

Fixes #1424