### PR TITLE
refactor(task,worktree): scope commands to the current repository

### DIFF
--- a/docs/commands/dev.md
+++ b/docs/commands/dev.md
@@ -38,9 +38,9 @@ gt b -N feature/demo
 ## worktree <Badge text="v3.10+"/>
 If you find yourself wanting to work on several branches of a repository at the same time,
 git's [worktree](https://git-scm.com/docs/git-worktree) feature is invaluable. The `gt worktree`
-command brings the same ergonomics you get from `gt open` and `gt switch` to worktrees: it
-prepares (and, if necessary, clones) the repository, creates a worktree for the branch you've
-asked for, and then launches your chosen application inside it.
+command brings the same ergonomics you get from `gt open` and `gt switch` to worktrees: from within
+a repository it creates a worktree for the branch you've asked for and then launches your chosen
+application inside it.
 
 Worktrees are stored within the [`worktrees` directory](../config/README.md#worktrees) configured in
 your config file, which defaults to a `worktrees` folder inside your development directory. Each
@@ -48,9 +48,8 @@ worktree is placed in its own folder named after the repository and branch, with
 repository's full name appended to keep repositories with the same short name from colliding.
 
 ::: tip
-You can run `gt worktree` from anywhere by specifying a repository (`gt w <repo> <branch> [app]`),
-or run it from within a repository and omit the repository name to operate on the current repo
-(`gt w <branch> [app]`), just like `gt switch`.
+Run `gt worktree` from within a repository to operate on the current repo (`gt w <branch> [app]`),
+just like `gt switch`.
 
 If you don't specify a branch, Git-Tool will list the existing worktrees for the repository. The
 primary working tree is labelled `[primary]`, and worktrees with a detached `HEAD` are shown with
@@ -93,23 +92,20 @@ to clean them up once they've been merged.
 
 #### Example
 ``` powershell
-# Create (or open) a worktree for the feat/forgejo branch of github-backup
-gt w github-backup feat/forgejo
+# Create (or open) a worktree for the current repository's feat/forgejo branch
+gt w feat/forgejo
 
 # Open the feat/forgejo worktree in VS Code
-gt w github-backup feat/forgejo code
-
-# Open a worktree for the current repository's feature/demo branch
-gt w feature/demo
+gt w feat/forgejo code
 
 # Base a new worktree branch on origin/main
-gt w github-backup feat/forgejo --base origin/main
+gt w feat/forgejo --base origin/main
 
 # Open a throwaway worktree that is removed once you exit the shell
-gt w github-backup feat/forgejo --rm
+gt w feat/forgejo --rm
 
-# List the existing worktrees for a repository
-gt w github-backup
+# List the existing worktrees for the current repository
+gt w
 ```
 
 ## ignore <Badge text="v1.0+"/>

--- a/docs/commands/tasks.md
+++ b/docs/commands/tasks.md
@@ -2,7 +2,7 @@
 Many repositories come with a set of common operations you find yourself running over and over
 again: building the project, running its tests, starting a development server, and so on. Git-Tool
 lets each repository describe these operations as named **tasks** in a `git-tool.yml` file at its
-root, and provides the `gt task` command to run them from anywhere.
+root, and provides the `gt task` command to run them from within the repository.
 
 Because tasks run commands defined by a repository, Git-Tool will only execute them once you have
 confirmed that you **trust** the repository's configuration. This page covers the `git-tool.yml`
@@ -39,10 +39,8 @@ using the same engine as your apps, so they benefit from the same
 [templating](../config/templates.md) and signal forwarding.
 
 ## task <Badge text="v3.11+"/>
-The `gt task` command runs a task defined in a repository's `git-tool.yml` file. You can run it from
-within a repository, or against any repository by name. If the repository has not been cloned yet, it
-will be cloned automatically before the task runs (just like the [`gt worktree`](dev.md#worktree)
-command).
+The `gt task` command runs a task defined in the current repository's `git-tool.yml` file. Run it
+from within a repository, or with no arguments to list the tasks available in the current repository.
 
 ::: tip
 The first time Git-Tool encounters a repository's `git-tool.yml` (and any time it changes), you will
@@ -58,9 +56,6 @@ be shown its contents and asked whether you trust it. See [Trust](#trust) below 
 ``` powershell
 # Run the 'build' task in the current repository
 gt t build
-
-# Run the 'test' task in a specific repository (cloning it first if necessary)
-gt run github.com/sierrasoftworks/git-tool test
 
 # List the tasks available in the current repository
 gt task

--- a/src/commands/task.rs
+++ b/src/commands/task.rs
@@ -1,7 +1,6 @@
 use super::*;
-use crate::engine::{Identifier, Repo, RepoConfig, Target};
+use crate::engine::RepoConfig;
 use crate::errors::HumanErrorResultExt;
-use crate::tasks::*;
 use clap::Arg;
 use itertools::Itertools;
 use tracing_batteries::prelude::*;
@@ -19,67 +18,19 @@ impl CommandRunnable for TaskCommand {
         clap::Command::new(self.name())
             .version("1.0")
             .visible_aliases(["t", "run"])
-            .about("runs a task defined in a repository's 'git-tool.yml' file")
-            .long_about("This command runs a named task defined in a repository's 'git-tool.yml' configuration file. You can run it from within a repository (`gt task <task>`) or against a specific repository (`gt task <repo> <task>`). If the repository has not been cloned yet, it will be cloned automatically before the task runs.
+            .about("runs a task defined in the current repository's 'git-tool.yml' file")
+            .long_about("This command runs a named task defined in the current repository's 'git-tool.yml' configuration file. Run it from within a repository (`gt task <task>`), or with no arguments to list the tasks available in the current repository.
 
 Tasks are only executed once you have confirmed that you trust the repository's configuration. The first time a repository's configuration is seen (or whenever it changes) you will be shown its contents and asked whether you trust it.")
-            .arg(Arg::new("repo")
-                    .help("The repository to run the task in, or the name of the task when run within a repository.")
-                    .index(1))
             .arg(Arg::new("task")
                     .help("The name of the task to run.")
-                    .index(2))
+                    .index(1))
     }
 
     #[tracing::instrument(name = "gt task", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, human_errors::Error> {
-        let first = matches.get_one::<String>("repo");
-        let second = matches.get_one::<String>("task");
-
-        let provided: Vec<&String> = [first, second].into_iter().flatten().collect();
-
-        let current_repo = core.resolver().get_current_repo();
-
-        let (repo, task_name): (Repo, Option<String>) = if let Ok(current) = current_repo {
-            match provided.as_slice() {
-                // gt task <repo> <task>
-                [repo, task] => (self.resolve_repo(core, repo)?, Some((*task).clone())),
-                // gt task <task> (within the current repository)
-                [value] => (current, Some((*value).clone())),
-                // gt task (list the tasks available in the current repository)
-                [] => (current, None),
-                _ => unreachable!("clap only provides up to two positional arguments"),
-            }
-        } else {
-            match provided.as_slice() {
-                [repo, task] => (self.resolve_repo(core, repo)?, Some((*task).clone())),
-                [_value] => {
-                    return Err(human_errors::user(
-                        "You are not currently within a repository, so you need to specify both the repository and the task to run.",
-                        &[
-                            "Run the task like this: 'git-tool task github.com/sierrasoftworks/git-tool build'.",
-                        ],
-                    ));
-                }
-                [] => {
-                    return Err(human_errors::user(
-                        "You did not specify a repository or a task to run.",
-                        &[
-                            "Run the task like this: 'git-tool task github.com/sierrasoftworks/git-tool build'.",
-                        ],
-                    ));
-                }
-                _ => unreachable!("clap only provides up to two positional arguments"),
-            }
-        };
-
-        // Ensure the repository has been cloned before we try to load its
-        // configuration or run any tasks.
-        if !repo.exists() {
-            sequence![GitClone::default()]
-                .apply_repo(core, &repo)
-                .await?;
-        }
+        let repo = core.resolver().get_current_repo()?;
+        let task_name = matches.get_one::<String>("task").cloned();
 
         let config = RepoConfig::for_repo(&repo)?.ok_or_else(|| {
             human_errors::user(
@@ -138,9 +89,6 @@ Tasks are only executed once you have confirmed that you trust the repository's 
 
     #[tracing::instrument(name = "gt complete -- gt task", skip(self, core, completer, _matches))]
     async fn complete(&self, core: &Core, completer: &Completer, _matches: &ArgMatches) {
-        completer.offer_aliases(core);
-        completer.offer_repos(core);
-
         if let Ok(repo) = core.resolver().get_current_repo()
             && let Ok(Some(config)) = RepoConfig::for_repo(&repo)
         {
@@ -149,18 +97,10 @@ Tasks are only executed once you have confirmed that you trust the repository's 
     }
 }
 
-impl TaskCommand {
-    fn resolve_repo(&self, core: &Core, value: &str) -> Result<Repo, human_errors::Error> {
-        let identifier: Identifier = value.parse()?;
-        core.resolver().get_best_repo(&identifier)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::engine::*;
-    use mockall::predicate::eq;
 
     fn write_repo_config(path: &std::path::Path, contents: &str) {
         std::fs::create_dir_all(path).unwrap();
@@ -206,45 +146,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_task_against_specified_repo() {
+    async fn list_tasks_in_current_repo() {
         let cmd = TaskCommand {};
-        let args = cmd
-            .app()
-            .get_matches_from(vec!["task", "sierrasoftworks/test-task", "build"]);
+        let args = cmd.app().get_matches_from(vec!["task"]);
 
         let temp = tempfile::tempdir().unwrap();
         let repo_path = temp.path().join("repo");
         write_repo_config(&repo_path, EXAMPLE_CONFIG);
 
-        let repo = Repo::new("gh:sierrasoftworks/test-task", repo_path.clone());
-        let trusted_repo = repo.to_string();
-        let config = RepoConfig::for_repo(&repo).unwrap().unwrap();
-
-        let cfg = Config::for_dev_directory(temp.path())
-            .with_trusted_repo(trusted_repo, config.hash().unwrap());
-
-        let identifier: Identifier = "sierrasoftworks/test-task".parse().unwrap();
+        let console = crate::console::mock();
         let core = Core::builder()
-            .with_config(cfg)
-            .with_null_console()
+            .with_config_for_dev_directory(temp.path())
+            .with_console(console.clone())
             .with_mock_resolver(move |mock| {
                 let repo_path = repo_path.clone();
-                mock.expect_get_current_repo()
-                    .returning(|| Err(human_errors::user("not in a repo", &[])));
-                mock.expect_get_best_repo()
-                    .with(eq(identifier.clone()))
-                    .returning(move |_| {
-                        Ok(Repo::new("gh:sierrasoftworks/test-task", repo_path.clone()))
-                    });
-            })
-            .with_mock_launcher(|mock| {
-                mock.expect_run()
-                    .times(1)
-                    .returning(|_, _| Box::pin(async { Ok(0) }));
+                mock.expect_get_current_repo().returning(move || {
+                    Ok(Repo::new("gh:sierrasoftworks/test-task", repo_path.clone()))
+                });
             })
             .build();
 
         cmd.assert_run_successful(&core, &args).await;
+        assert!(
+            console.to_string().contains("build"),
+            "the available tasks should be listed"
+        );
     }
 
     #[tokio::test]

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::engine::{Identifier, Repo, Target};
+use crate::engine::{Repo, Target};
 use crate::errors::HumanErrorResultExt;
 use crate::git;
 use crate::tasks::*;
@@ -22,18 +22,15 @@ impl CommandRunnable for WorktreeCommand {
             .version("1.0")
             .visible_aliases(["w", "wt"])
             .about("opens a git worktree for a branch using an application defined in your config")
-            .long_about("This command prepares a git worktree for the specified branch and launches an application within it. It behaves like a combination of the `switch` and `open` commands: you can run it from anywhere by specifying a repository (`gt w <repo> <branch> [app]`), or from within a repository to operate on the current repo (`gt w <branch> [app]`).
+            .long_about("This command prepares a git worktree for the specified branch of the current repository and launches an application within it. It behaves like a combination of the `switch` and `open` commands: run it from within a repository to operate on the current repo (`gt w <branch> [app]`).
 
-If the base repository has not been cloned yet, it will be cloned automatically. Worktrees are created within the worktree directory configured in your config file (defaulting to `$DEV_DIRECTORY/worktrees`). When the requested branch does not exist yet, it will be created (use `--no-create` to disable this). The branch a new worktree is based on can be controlled with `--base`.")
-            .arg(Arg::new("repo")
-                    .help("The repository or branch to open a worktree for.")
-                    .index(1))
+Worktrees are created within the worktree directory configured in your config file (defaulting to `$DEV_DIRECTORY/worktrees`). When the requested branch does not exist yet, it will be created (use `--no-create` to disable this). The branch a new worktree is based on can be controlled with `--base`.")
             .arg(Arg::new("branch")
-                    .help("The branch or application to use.")
-                    .index(2))
+                    .help("The branch to open a worktree for.")
+                    .index(1))
             .arg(Arg::new("app")
                     .help("The application to launch.")
-                    .index(3))
+                    .index(2))
             .arg(Arg::new("no-create")
                     .short('N')
                     .long("no-create")
@@ -51,92 +48,19 @@ If the base repository has not been cloned yet, it will be cloned automatically.
 
     #[tracing::instrument(name = "gt worktree", err, skip(self, core, matches))]
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, human_errors::Error> {
-        let first = matches.get_one::<String>("repo");
-        let second = matches.get_one::<String>("branch");
-        let third = matches.get_one::<String>("app");
         let no_create = matches.get_flag("no-create");
         let base = matches.get_one::<String>("base");
         let remove_after = matches.get_flag("rm");
 
-        // Positional arguments are always filled in order, so collapsing them into
-        // a contiguous slice lets us reason about how many were provided.
-        let provided: Vec<&String> = [first, second, third].into_iter().flatten().collect();
+        let repo = core.resolver().get_current_repo()?;
 
-        let current_repo = core.resolver().get_current_repo();
-
-        // Resolve the base repository, the branch, and the requested application
-        // following a context-first strategy.
-        let (repo, branch, app_arg): (Repo, Option<String>, Option<String>) = if let Ok(current) =
-            current_repo
-        {
-            match provided.as_slice() {
-                // gt w <repo> <branch> <app>
-                [repo, branch, app] => (
-                    self.resolve_repo(core, repo)?,
-                    Some((*branch).clone()),
-                    Some((*app).clone()),
-                ),
-                // gt w <value> [second]
-                [value, rest @ ..] => {
-                    let maybe_second = rest.first().copied();
-                    let second_is_app = maybe_second
-                        .map(|v| core.config().get_app(v).is_some())
-                        .unwrap_or(false);
-
-                    match maybe_second {
-                        // gt w <repo> <branch>: two non-app arguments are an
-                        // unambiguous indication that the first names a
-                        // repository and the second names the branch.
-                        Some(second) if !second_is_app => (
-                            self.resolve_repo(core, value)?,
-                            Some((*second).clone()),
-                            None,
-                        ),
-                        // gt w <branch> <app>: the branch takes precedence and
-                        // the second argument selects the application.
-                        Some(second) => (current, Some((*value).clone()), Some((*second).clone())),
-                        // gt w <branch>: a single argument is always treated as
-                        // a branch within the current repository.
-                        None => (current, Some((*value).clone()), None),
-                    }
-                }
-                // gt w (no arguments) -> list worktrees for the current repo
-                [] => (current, None, None),
-            }
-        } else {
-            match provided.as_slice() {
-                [repo, rest @ ..] => (
-                    self.resolve_repo(core, repo)?,
-                    rest.first().map(|v| (*v).clone()),
-                    rest.get(1).map(|v| (*v).clone()),
-                ),
-                [] => {
-                    return Err(human_errors::user(
-                        "You did not specify the name of a repository to use.",
-                        &[
-                            "Remember to specify a repository name like this: 'git-tool worktree github.com/sierrasoftworks/git-tool feature/example'.",
-                        ],
-                    ));
-                }
-            }
-        };
+        let branch = matches.get_one::<String>("branch").cloned();
+        let app_arg = matches.get_one::<String>("app").cloned();
 
         // Without a branch we list the existing worktrees for the repository.
         let branch = match branch {
             Some(branch) => branch,
             None => {
-                if !repo.exists() {
-                    return Err(human_errors::user(
-                        format!(
-                            "The repository '{}' has not been cloned yet, so it has no worktrees.",
-                            repo.get_full_name()
-                        ),
-                        &[
-                            "Specify a branch name to create a worktree, like this: 'git-tool worktree feature/example'.",
-                        ],
-                    ));
-                }
-
                 let worktrees = git::git_worktree_list(&repo.get_path()).await?;
                 let mut output = core.output();
                 // `git worktree list` always reports the primary working tree
@@ -175,13 +99,6 @@ If the base repository has not been cloned yet, it will be cloned automatically.
                 )
             })?,
         };
-
-        // Ensure the base repository has been cloned before creating a worktree.
-        if !repo.exists() {
-            sequence![GitClone::default()]
-                .apply_repo(core, &repo)
-                .await?;
-        }
 
         let worktree_path = core
             .config()
@@ -234,7 +151,7 @@ If the base repository has not been cloned yet, it will be cloned automatically.
                     worktree_path.display()
                 ),
                 &[
-                    "Commit or discard your changes within the worktree and then remove it manually with 'git worktree remove <path>'.",
+                    "Commit or discard your changes within the worktree and then remove it manually with 'git-tool prune'.",
                 ],
             )?;
 
@@ -252,9 +169,7 @@ If the base repository has not been cloned yet, it will be cloned automatically.
         completer.offer("--no-create");
         completer.offer("--base");
         completer.offer("--rm");
-        completer.offer_aliases(core);
         completer.offer_apps(core);
-        completer.offer_repos(core);
 
         if let Ok(repo) = core.resolver().get_current_repo()
             && let Ok(branches) = git::git_branches(&repo.get_path()).await
@@ -265,11 +180,6 @@ If the base repository has not been cloned yet, it will be cloned automatically.
 }
 
 impl WorktreeCommand {
-    fn resolve_repo(&self, core: &Core, value: &str) -> Result<Repo, human_errors::Error> {
-        let identifier: Identifier = value.parse()?;
-        core.resolver().get_best_repo(&identifier)
-    }
-
     /// Applies the worktree automation defined in a repository's 'git-tool.yml'
     /// configuration: it creates the requested symlinks from the worktree back to
     /// the original repository and then runs the configured setup tasks within the
@@ -505,15 +415,6 @@ mod tests {
                 Ok(Repo::new(
                     "gh:sierrasoftworks/test-worktree-command",
                     repo_path.clone(),
-                ))
-            });
-
-            // Branch names do not resolve to repositories, so the resolver
-            // reports that no matching repository could be found.
-            mock.expect_get_best_repo().returning(|identifier| {
-                Err(human_errors::user(
-                    format!("No repository matched '{identifier}'."),
-                    &["Specify a valid repository name."],
                 ))
             });
         });
@@ -765,81 +666,6 @@ mod tests {
         assert!(
             console.to_string().contains("ignoring '--base'"),
             "a warning should be printed when --base is ignored for an existing branch"
-        );
-    }
-
-    #[tokio::test]
-    async fn run_in_repo_prefers_branch_over_repo_for_single_argument() {
-        let cmd = WorktreeCommand {};
-        let temp = tempdir().unwrap();
-
-        let cfg = Config::for_dev_directory(temp.path());
-        let core = Core::builder().with_config(cfg);
-
-        let repo = Repo::new(
-            "gh:sierrasoftworks/test-worktree-command",
-            temp.path().join("repo"),
-        );
-
-        // The resolver reports the current repository and, crucially, will
-        // happily resolve the single argument as a repository name. A lone
-        // argument must still be treated as a branch within the current repo.
-        let repo_path = repo.get_path();
-        let other_repo_path = temp.path().join("other");
-        let core = core.with_mock_resolver(move |mock| {
-            let repo_path = repo_path.clone();
-            mock.expect_get_current_repo().returning(move || {
-                Ok(Repo::new(
-                    "gh:sierrasoftworks/test-worktree-command",
-                    repo_path.clone(),
-                ))
-            });
-
-            let other_repo_path = other_repo_path.clone();
-            mock.expect_get_best_repo().returning(move |_| {
-                Ok(Repo::new(
-                    "gh:sierrasoftworks/feature",
-                    other_repo_path.clone(),
-                ))
-            });
-        });
-
-        let expected_path = temp
-            .path()
-            .join("worktrees")
-            .join(WorktreeCommand::worktree_dir_name(&repo, "feature"));
-        let expected_for_assert = expected_path.clone();
-
-        let core = core
-            .with_mock_launcher(move |mock| {
-                let expected_path = expected_path.clone();
-                mock.expect_run()
-                    .withf(move |app, target| {
-                        // The worktree must be created inside the current repo,
-                        // not the repository the argument resolves to.
-                        app.get_name() == "shell" && target.get_path() == expected_path
-                    })
-                    .returning(|_, _| Box::pin(async { Ok(0) }));
-            })
-            .build();
-
-        sequence!(GitInit {}, GitCheckout { branch: "main" })
-            .apply_repo(&core, &repo)
-            .await
-            .unwrap();
-        commit_initial(&repo).await;
-
-        let args = cmd.app().get_matches_from(vec!["worktree", "feature"]);
-        let status = cmd.run(&core, &args).await.unwrap();
-
-        assert_eq!(status, 0, "the launcher status code should be forwarded");
-        assert!(
-            expected_for_assert.join(".git").exists(),
-            "a worktree for the 'feature' branch should have been created in the current repo"
-        );
-        assert_eq!(
-            git::git_current_branch(&expected_for_assert).await.unwrap(),
-            "feature"
         );
     }
 


### PR DESCRIPTION
## Summary

The `gt task` and `gt worktree` commands previously supported running against arbitrary repositories. This complicated their command argument lists, the interpretation of those arguments, and a range of other edge cases (auto-cloning, context-vs-explicit disambiguation, etc.).

These commands now operate **solely within the current repository**, in the same way `gt prune` does. The result is significantly simpler code, argument parsing, and behaviour.

## Changes

### `gt task` ([src/commands/task.rs](src/commands/task.rs))
- Dropped the `repo` positional argument and all the context-vs-explicit argument disambiguation, automatic cloning, and the `resolve_repo` helper.
- Resolves the current repo via `get_current_repo()`, takes an optional `<task>` name, and lists available tasks when omitted.
- Completion no longer offers aliases/repos — just the current repo's task names.

### `gt worktree` ([src/commands/worktree.rs](src/commands/worktree.rs))
- Dropped the `repo` argument, the three-way positional parsing, the "not in a repo" branch, the not-cloned-yet handling, the clone-before-create step, and `resolve_repo`.
- Arguments are now simply `<branch> [app]`, resolved against the current repo.
- Completion no longer offers aliases/repos.

### Tests
- Removed the `run_task_against_specified_repo` and the worktree single-argument disambiguation tests (now moot).
- Added a `list_tasks_in_current_repo` test.
- Cleaned up obsolete `get_best_repo` mocks.

### Docs
- Updated [docs/commands/tasks.md](docs/commands/tasks.md) and the worktree section of [docs/commands/dev.md](docs/commands/dev.md) to describe the current-repo-only behaviour and examples.

## Verification
- Full build is clean.
- All 254 tests pass.