### PR TITLE
fix(prune): filter branches and worktrees by pattern and subset flags

### DIFF
--- a/docs/commands/dev.md
+++ b/docs/commands/dev.md
@@ -157,11 +157,25 @@ repository which do not contain uncommitted changes. Worktrees with pending work
 are left in place so that you don't lose anything, and you'll be asked to confirm
 before anything is removed.
 
+You can optionally provide one or more patterns to only prune branches and
+worktrees whose branch name contains one of those patterns, and use the
+`--branches`/`--worktrees` flags to restrict the operation to just branches or
+just worktrees (by default both are pruned).
+
 #### Options
  - `-y`, `--yes` will skip the confirmation prompt and remove any branches that are found.
+ - `-b`, `--branches` will only prune merged branches (worktrees are left untouched).
+ - `-w`, `--worktrees` will only prune clean worktrees (branches are left untouched).
+ - `[pattern]...` restricts pruning to branches and worktrees whose branch name contains one of the provided patterns.
 
 #### Example
 ``` powershell
 # Remove any merged branches from your local repository
 gt prune
+
+# Only remove merged branches whose name contains "feature/"
+gt prune --branches feature/
+
+# Only remove clean worktrees
+gt prune --worktrees
 ```

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -36,8 +36,22 @@ impl CommandRunnable for PruneCommand {
                     .help("Do not prompt for confirmation before deleting branches")
                     .action(clap::ArgAction::SetTrue),
             )
+            .arg(
+                Arg::new("branches")
+                    .long("branches")
+                    .short('b')
+                    .help("Prune merged branches (enabled by default unless --worktrees is set)")
+                    .action(clap::ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("worktrees")
+                    .long("worktrees")
+                    .short('w')
+                    .help("Prune clean worktrees (enabled by default unless --branches is set)")
+                    .action(clap::ArgAction::SetTrue),
+            )
             .arg(Arg::new("pattern")
-                .help("The branch patterns which should be pruned")
+                .help("Only prune branches and worktrees whose branch name contains one of these patterns")
                 .action(clap::ArgAction::Append))
     }
 
@@ -45,61 +59,45 @@ impl CommandRunnable for PruneCommand {
     async fn run(&self, core: &Core, matches: &ArgMatches) -> Result<i32, human_errors::Error> {
         let repo = core.resolver().get_current_repo()?;
 
-        let default_branch = git::git_default_branch(&repo.get_path()).await.wrap_user_err(
-            "Could not determine the default branch for your repository, this probably means that you do not have a synchronized `origin`.",
-            &["Make sure that you have a correctly configured `origin` and that you have run `git fetch` before running this command again."],
-        )?;
+        // Determine which subsets we should prune. When neither flag is provided we
+        // prune both branches and worktrees; specifying one flag restricts the
+        // operation to just that subset.
+        let (prune_branches, prune_worktrees) =
+            match (matches.get_flag("branches"), matches.get_flag("worktrees")) {
+                (true, false) => (true, false),
+                (false, true) => (false, true),
+                _ => (true, true),
+            };
 
-        let merged = match git::git_merged_branches(&repo.get_path()).await {
-            Ok(merged) => merged,
-            Err(e) => {
-                return Err(human_errors::wrap_user(
-                    e,
-                    "Could not determine the branches that have been merged into the default branch.",
-                    &[
-                        "Make sure that you have a correctly configured `origin` and that you have run `git fetch` before running this command again.",
-                    ],
-                ));
-            }
+        // The patterns are matched against branch names; an empty pattern list
+        // matches everything.
+        let patterns: Vec<String> = matches
+            .get_many::<String>("pattern")
+            .map(|values| values.cloned().collect())
+            .unwrap_or_default();
+
+        let branches_to_remove: Vec<String> = if prune_branches {
+            self.get_prune_branches(&repo, &patterns).await?
+        } else {
+            Vec::new()
         };
 
-        let to_remove: Vec<&String> = merged
-            .iter()
-            .filter(|&b| b != &default_branch)
-            .unique()
-            .collect();
+        let worktrees_to_remove = if prune_worktrees {
+            self.get_prune_worktrees(&repo, &patterns).await?
+        } else {
+            Vec::new()
+        };
 
-        // Identify worktrees for this repository which have no uncommitted changes
-        // and can therefore be safely removed. `git worktree list` always reports the
-        // primary working tree (the repository itself) first, so we skip that entry
-        // and keep any linked worktree with pending work so the user doesn't lose
-        // anything.
-        let repo_path = repo.get_path();
-
-        let mut worktrees_to_remove = Vec::new();
-        for worktree in git::git_worktree_list(&repo_path)
-            .await?
-            .into_iter()
-            .skip(1)
-        {
-            if git::git_worktree_is_clean(&worktree.path)
-                .await
-                .unwrap_or(false)
-            {
-                worktrees_to_remove.push(worktree);
-            }
-        }
-
-        if to_remove.is_empty() && worktrees_to_remove.is_empty() {
+        if branches_to_remove.is_empty() && worktrees_to_remove.is_empty() {
             writeln!(core.output(), "No branches or worktrees to remove").to_human_error()?;
             return Ok(0);
         }
 
         if !matches.get_flag("yes") {
-            if !to_remove.is_empty() {
+            if !branches_to_remove.is_empty() {
                 writeln!(core.output(), "The following branches will be removed:")
                     .to_human_error()?;
-                for branch in to_remove.iter() {
+                for branch in branches_to_remove.iter() {
                     writeln!(core.output(), "  {branch}").to_human_error()?;
                 }
                 writeln!(core.output()).to_human_error()?;
@@ -140,10 +138,8 @@ impl CommandRunnable for PruneCommand {
             }));
         }
 
-        for branch in to_remove {
-            cleanup.push(std::sync::Arc::new(tasks::GitBranchDelete {
-                branch: branch.clone(),
-            }));
+        for branch in branches_to_remove {
+            cleanup.push(std::sync::Arc::new(tasks::GitBranchDelete { branch }));
         }
 
         tasks::Sequence::new(cleanup)
@@ -160,10 +156,89 @@ impl CommandRunnable for PruneCommand {
     async fn complete(&self, core: &Core, completer: &Completer, _matches: &ArgMatches) {
         if let Ok(repo) = core.resolver().get_current_repo() {
             completer.offer("--yes");
+            completer.offer("--branches");
+            completer.offer("--worktrees");
             if let Ok(branches) = git::git_merged_branches(&repo.get_path()).await {
                 completer.offer_many(branches.iter().unique().sorted());
             }
         }
+    }
+}
+
+impl PruneCommand {
+    async fn get_prune_branches(
+        &self,
+        repo: &engine::Repo,
+        patterns: &[String],
+    ) -> Result<Vec<String>, human_errors::Error> {
+        let merged = match git::git_merged_branches(&repo.get_path()).await {
+            Ok(merged) => merged,
+            Err(e) => {
+                return Err(human_errors::wrap_user(
+                    e,
+                    "Could not determine the branches that have been merged into the default branch.",
+                    &[
+                        "Make sure that you have a correctly configured `origin` and that you have run `git fetch` before running this command again.",
+                    ],
+                ));
+            }
+        };
+
+        let default_branch = git::git_default_branch(&repo.get_path()).await.wrap_user_err(
+            "Could not determine the default branch for your repository, this probably means that you do not have a synchronized `origin`.",
+            &["Make sure that you have a correctly configured `origin` and that you have run `git fetch` before running this command again."],
+        )?;
+
+        let candidates: Vec<String> = merged
+            .into_iter()
+            .filter(|b| b != &default_branch)
+            .unique()
+            .collect();
+
+        Ok(crate::search::matches_any(&patterns, candidates))
+    }
+
+    async fn get_prune_worktrees(
+        &self,
+        repo: &engine::Repo,
+        patterns: &[String],
+    ) -> Result<Vec<git::Worktree>, human_errors::Error> {
+        let worktrees: Vec<git::Worktree> = git::git_worktree_list(&repo.get_path())
+            .await?
+            .into_iter()
+            .skip(1)
+            .collect();
+
+        // Worktrees are matched against their branch name; a detached HEAD (no
+        // branch) is never matched when patterns are provided.
+        let matching_branches: std::collections::HashSet<String> = crate::search::matches_any(
+            &patterns,
+            worktrees.iter().filter_map(|w| w.branch.clone()),
+        )
+        .into_iter()
+        .collect();
+
+        let mut worktrees_to_remove = Vec::new();
+
+        for worktree in worktrees {
+            let matches = match &worktree.branch {
+                Some(branch) => matching_branches.contains(branch),
+                None => patterns.is_empty(),
+            };
+
+            if !matches {
+                continue;
+            }
+
+            if git::git_worktree_is_clean(&worktree.path)
+                .await
+                .unwrap_or(false)
+            {
+                worktrees_to_remove.push(worktree);
+            }
+        }
+
+        Ok(worktrees_to_remove)
     }
 }
 
@@ -445,6 +520,201 @@ mod tests {
             "a worktree with uncommitted changes must not be removed"
         );
         assert!(repo.valid(), "the repository should still be valid");
+    }
+
+    #[tokio::test]
+    async fn prune_pattern_filters_branches() {
+        let cmd: PruneCommand = PruneCommand {};
+
+        let temp = tempdir().unwrap();
+
+        let console = crate::console::mock_with_input("y\n");
+        let (core, repo) = setup_test_repo_with_remote(
+            Core::builder()
+                .with_config_for_dev_directory(temp.path())
+                .with_console(console.clone()),
+            &temp,
+        )
+        .await;
+
+        git::git_cmd(
+            tokio::process::Command::new("git")
+                .current_dir(repo.get_path())
+                .arg("merge")
+                .arg("feature/test2"),
+        )
+        .await
+        .unwrap();
+
+        // A pattern which doesn't match the merged branch should leave everything intact.
+        let args: ArgMatches = cmd.app().get_matches_from(vec!["prune", "does-not-match"]);
+        cmd.assert_run_successful(&core, &args).await;
+
+        let mut branches = git::git_branches(&repo.get_path()).await.unwrap();
+        branches.sort();
+        assert_eq!(
+            branches,
+            vec!["feature/test", "feature/test2", "main"],
+            "no branches should be removed when the pattern doesn't match"
+        );
+
+        // A matching pattern should remove the merged branch.
+        let args: ArgMatches = cmd.app().get_matches_from(vec!["prune", "test2"]);
+        cmd.assert_run_successful(&core, &args).await;
+
+        let mut branches = git::git_branches(&repo.get_path()).await.unwrap();
+        branches.sort();
+        assert_eq!(
+            branches,
+            vec!["feature/test", "main"],
+            "only the branch matching the pattern should be removed"
+        );
+    }
+
+    #[tokio::test]
+    async fn prune_branches_only_skips_worktrees() {
+        let cmd: PruneCommand = PruneCommand {};
+
+        let temp = tempdir().unwrap();
+
+        let console = crate::console::mock_with_input("y\n");
+        let (core, repo) = setup_test_repo_with_remote(
+            Core::builder()
+                .with_config_for_dev_directory(temp.path())
+                .with_console(console.clone()),
+            &temp,
+        )
+        .await;
+
+        git::git_cmd(
+            tokio::process::Command::new("git")
+                .current_dir(repo.get_path())
+                .arg("merge")
+                .arg("feature/test2"),
+        )
+        .await
+        .unwrap();
+
+        let worktree_path = temp.path().join("worktrees").join("clean");
+        git::git_worktree_add(
+            &repo.get_path(),
+            &worktree_path,
+            "feature/clean-worktree",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let args: ArgMatches = cmd.app().get_matches_from(vec!["prune", "--branches"]);
+        cmd.assert_run_successful(&core, &args).await;
+
+        assert!(
+            worktree_path.exists(),
+            "worktrees should be left untouched when --branches is specified"
+        );
+
+        let mut branches = git::git_branches(&repo.get_path()).await.unwrap();
+        branches.sort();
+        assert!(
+            !branches.contains(&"feature/test2".to_string()),
+            "the merged branch should have been removed"
+        );
+    }
+
+    #[tokio::test]
+    async fn prune_worktrees_only_skips_branches() {
+        let cmd: PruneCommand = PruneCommand {};
+
+        let temp = tempdir().unwrap();
+
+        let console = crate::console::mock_with_input("y\n");
+        let (core, repo) = setup_test_repo_with_remote(
+            Core::builder()
+                .with_config_for_dev_directory(temp.path())
+                .with_console(console.clone()),
+            &temp,
+        )
+        .await;
+
+        git::git_cmd(
+            tokio::process::Command::new("git")
+                .current_dir(repo.get_path())
+                .arg("merge")
+                .arg("feature/test2"),
+        )
+        .await
+        .unwrap();
+
+        let worktree_path = temp.path().join("worktrees").join("clean");
+        git::git_worktree_add(
+            &repo.get_path(),
+            &worktree_path,
+            "feature/clean-worktree",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let args: ArgMatches = cmd.app().get_matches_from(vec!["prune", "--worktrees"]);
+        cmd.assert_run_successful(&core, &args).await;
+
+        assert!(
+            !worktree_path.exists(),
+            "the clean worktree should have been removed"
+        );
+
+        let mut branches = git::git_branches(&repo.get_path()).await.unwrap();
+        branches.sort();
+        assert!(
+            branches.contains(&"feature/test2".to_string()),
+            "merged branches should be left untouched when --worktrees is specified"
+        );
+    }
+
+    #[tokio::test]
+    async fn prune_pattern_filters_worktrees() {
+        let cmd: PruneCommand = PruneCommand {};
+
+        let temp = tempdir().unwrap();
+
+        let console = crate::console::mock_with_input("y\n");
+        let (core, repo) = setup_test_repo_with_remote(
+            Core::builder()
+                .with_config_for_dev_directory(temp.path())
+                .with_console(console.clone()),
+            &temp,
+        )
+        .await;
+
+        let keep_path = temp.path().join("worktrees").join("keep");
+        git::git_worktree_add(&repo.get_path(), &keep_path, "feature/keep-me", true, None)
+            .await
+            .unwrap();
+
+        let remove_path = temp.path().join("worktrees").join("remove");
+        git::git_worktree_add(
+            &repo.get_path(),
+            &remove_path,
+            "feature/remove-me",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let args: ArgMatches = cmd.app().get_matches_from(vec!["prune", "remove-me"]);
+        cmd.assert_run_successful(&core, &args).await;
+
+        assert!(
+            keep_path.exists(),
+            "worktrees that don't match the pattern should be preserved"
+        );
+        assert!(
+            !remove_path.exists(),
+            "worktrees matching the pattern should be removed"
+        );
     }
 
     #[tokio::test]

--- a/src/completion/completer.rs
+++ b/src/completion/completer.rs
@@ -1,5 +1,5 @@
 use crate::engine::Core;
-use crate::{console::ConsoleProvider, search::matches};
+use crate::{console::ConsoleProvider, search::fuzzy_matches};
 use itertools::Itertools;
 use std::{fmt::Display, sync::Arc};
 
@@ -22,7 +22,7 @@ impl Completer {
 
     pub fn offer<S: AsRef<str>>(&self, completion: S) {
         let completion = completion.as_ref();
-        if !matches(completion, &self.filter) {
+        if !fuzzy_matches(completion, &self.filter) {
             return;
         }
         let mut out = self.console.output();

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1,5 +1,5 @@
 mod v1;
 mod v2;
 
-pub use v1::matches;
-pub use v2::{best_matches, best_matches_by};
+pub use v1::matches as fuzzy_matches;
+pub use v2::{best_matches, best_matches_by, matches_any};

--- a/src/search/v2.rs
+++ b/src/search/v2.rs
@@ -20,6 +20,49 @@ where
     matcher.order_by(values, to_key)
 }
 
+/// Returns the subset of `values` which match the provided `sequence` using
+/// fuzzy sequence matching. Unlike [`best_matches`], the original ordering of the
+/// values is preserved. An empty sequence matches every value.
+pub fn matches<T>(sequence: &str, values: T) -> Vec<T::Item>
+where
+    T: IntoIterator,
+    T::Item: AsRef<str>,
+{
+    if sequence.is_empty() {
+        return values.into_iter().collect();
+    }
+
+    let matcher = SequenceMatcher::new(sequence);
+    values
+        .into_iter()
+        .filter(|value| matcher.score(value.as_ref()).is_some())
+        .collect()
+}
+
+/// Returns the subset of `values` which match at least one of the provided
+/// `sequences` using fuzzy sequence matching, preserving the original ordering of
+/// the values. An empty list of sequences (or a list containing an empty
+/// sequence) matches every value.
+pub fn matches_any<S, T>(sequences: &[S], values: T) -> Vec<T::Item>
+where
+    S: AsRef<str>,
+    T: IntoIterator,
+    T::Item: AsRef<str>,
+{
+    if sequences.is_empty() {
+        return values.into_iter().collect();
+    }
+
+    values
+        .into_iter()
+        .filter(|value| {
+            sequences
+                .iter()
+                .any(|sequence| !matches(sequence.as_ref(), [value.as_ref()]).is_empty())
+        })
+        .collect()
+}
+
 #[cfg(test)]
 fn score<T: AsRef<str>>(value: T, sequence: &str) -> Option<f32> {
     let matcher = SequenceMatcher::new(sequence);
@@ -194,6 +237,41 @@ mod tests {
         assert_eq!(
             best_matches("main", vec!["main123", "main", "main456",]),
             vec!["main", "main123", "main456"]
+        );
+    }
+
+    #[test]
+    fn matches_filters_and_preserves_order() {
+        assert_eq!(
+            matches("test", vec!["feature/test", "main", "feature/test2"]),
+            vec!["feature/test", "feature/test2"],
+            "only matching values should be returned, in their original order"
+        );
+    }
+
+    #[test]
+    fn matches_empty_sequence_matches_everything() {
+        assert_eq!(
+            matches("", vec!["feature/test", "main"]),
+            vec!["feature/test", "main"]
+        );
+    }
+
+    #[test]
+    fn matches_any_filters_by_any_sequence() {
+        let patterns = vec!["test".to_string(), "main".to_string()];
+        assert_eq!(
+            matches_any(&patterns, vec!["feature/test", "main", "feature/other"]),
+            vec!["feature/test", "main"]
+        );
+    }
+
+    #[test]
+    fn matches_any_empty_sequences_match_everything() {
+        let patterns: Vec<String> = Vec::new();
+        assert_eq!(
+            matches_any(&patterns, vec!["feature/test", "main"]),
+            vec!["feature/test", "main"]
         );
     }
 }


### PR DESCRIPTION
The prune command's positional pattern argument is now used to filter both branches and worktrees by branch name using the fuzzy matcher from search::v2. Added --branches/-b and --worktrees/-w flags to restrict pruning to a single subset (both by default).

Adds search::v2::matches and matches_any helpers and renames the v1 predicate re-export to fuzzy_matches to avoid a name collision.