### PR TITLE
feat(windows): embed application manifest, icon and version metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-batteries",
+ "winresource",
 ]
 
 [[package]]
@@ -2674,6 +2675,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3037,6 +3047,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3065,6 +3090,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -3938,6 +3969,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winresource"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0986a8b1d586b7d3e4fe3d9ea39fb451ae22869dcea4aa109d287a374d866087"
+dependencies = [
+ "toml",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ shellexpand = "3"
 [target.'cfg(windows)'.dependencies]
 junction = "1"
 
+[target.'cfg(windows)'.build-dependencies]
+winresource = "0.1"
+
 [dev-dependencies]
 http = "1.4"
 mockall = "0.14.0"

--- a/assets/git-tool.exe.manifest
+++ b/assets/git-tool.exe.manifest
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity
+    type="win32"
+    name="SierraSoftworks.GitTool"
+    version="{VERSION}"
+  />
+  <description>A productivity tool for managing your git repositories.</description>
+
+  <!-- Run with the caller's privileges; Git-Tool never needs elevation, and
+       declaring this prevents Windows' installer-detection heuristics from
+       prompting for UAC. -->
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <!-- Declare support for the modern Windows releases that Git-Tool targets. -->
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 / Windows 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+    </application>
+  </compatibility>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <!-- Use UTF-8 for the active code page so repository paths and output
+           containing Unicode characters are handled correctly. -->
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+      <!-- Opt in to long path support for deeply nested repository trees. -->
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,34 @@
+fn main() {
+    #[cfg(windows)]
+    embed_windows_resources();
+}
+
+#[cfg(windows)]
+fn embed_windows_resources() {
+    let mut res = winresource::WindowsResource::new();
+
+    // Re-use the logo shipped with the documentation site as the executable icon.
+    res.set_icon("docs/.vuepress/public/favicon.ico");
+
+    // The assembly identity requires a four-part `major.minor.build.revision`
+    // version, so pad the three-part Cargo version with a trailing `.0`.
+    let manifest = std::fs::read_to_string("assets/git-tool.exe.manifest")
+        .expect("failed to read Windows manifest template");
+    let version = std::env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION not set by Cargo");
+    let manifest = manifest.replace("{VERSION}", &format!("{version}.0"));
+    res.set_manifest(&manifest);
+
+    res.set("ProductName", "Git-Tool");
+    res.set(
+        "FileDescription",
+        "A productivity tool for managing your git repositories.",
+    );
+    res.set("CompanyName", "Sierra Softworks");
+    res.set("LegalCopyright", "Copyright © Sierra Softworks");
+
+    res.compile()
+        .expect("failed to embed Windows executable resources");
+
+    println!("cargo:rerun-if-changed=assets/git-tool.exe.manifest");
+    println!("cargo:rerun-if-changed=docs/.vuepress/public/favicon.ico");
+}

--- a/src/update/fs.rs
+++ b/src/update/fs.rs
@@ -92,7 +92,7 @@ impl FileSystem for DefaultFileSystem {
 
     fn get_temp_app_path(&self, release: &Release) -> PathBuf {
         let file_name = format!(
-            "git-tool-update-{}{}",
+            "git-tool-{}{}",
             release.id,
             if cfg!(windows) { ".exe" } else { "" }
         );
@@ -151,9 +151,9 @@ mod tests {
         let path = fs.get_temp_app_path(&release);
 
         #[cfg(target_os = "windows")]
-        assert_eq!(path.file_name().unwrap(), "git-tool-update-1.0.0.exe");
+        assert_eq!(path.file_name().unwrap(), "git-tool-1.0.0.exe");
 
         #[cfg(not(target_os = "windows"))]
-        assert_eq!(path.file_name().unwrap(), "git-tool-update-1.0.0");
+        assert_eq!(path.file_name().unwrap(), "git-tool-1.0.0");
     }
 }


### PR DESCRIPTION
## Summary

Adds a Windows-only build step that embeds an application manifest, executable icon, and version metadata into the `git-tool.exe` binary.

## Changes

- **`build.rs`** — new build script, gated on `cfg(windows)`, using the `winresource` crate to:
  - Embed the docs site favicon (`docs/.vuepress/public/favicon.ico`) as the executable icon, keeping a single source of truth for the logo.
  - Template the manifest's `assemblyIdentity` version from `CARGO_PKG_VERSION` (padded to the required four-part form, e.g. `3.12.0` → `3.12.0.0`).
  - Set `VersionInfo` metadata (`ProductName`, `FileDescription`, `CompanyName`, `LegalCopyright`); `FileVersion`/`ProductVersion` are derived automatically from the Cargo version.

- **`assets/git-tool.exe.manifest`** — new application manifest declaring:
  - UTF-8 active code page (correct handling of Unicode repository paths/output).
  - Long-path awareness for deeply nested repository trees.
  - Supported OS versions (Windows 8.1, 10, 11).
  - `asInvoker` execution level (never requests elevation; avoids UAC installer-detection prompts).

- **`Cargo.toml`** — adds `winresource` under `[target.'cfg(windows)'.build-dependencies]`.

## Notes

- The build step is fully no-op on non-Windows platforms.
- Version metadata stays in sync with releases automatically, since the release workflow writes the version into `Cargo.toml` before building.
- The favicon currently ships small icon sizes only; Explorer's large-icon views will upscale. A multi-resolution `.ico` could be added later if a crisper app icon is desired.