### PR TITLE
ci: replace deprecated actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,11 +132,9 @@ jobs:
         if: matrix.setup
 
       - name: Get Rust Stable
-        uses: actions-rs/toolchain@v1.0.7
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
 
       - name: get secrets - sentry
         uses: hashicorp/vault-action@v4.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: rustup install
-        uses: actions-rs/toolchain@v1.0.7
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: clippy, rustfmt
-          override: true
 
       - name: install dependencies
         run: |
@@ -111,12 +109,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: rustup install nightly
-        uses: actions-rs/toolchain@v1.0.7
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
           components: llvm-tools-preview
 
       - name: cache ~/.cargo


### PR DESCRIPTION
## Summary

`actions-rs/toolchain` is deprecated and no longer maintained. This replaces all uses of it with the actively-maintained [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain).

## Changes

- **`.github/workflows/test.yml`** — both the `code-quality` and `test-platforms` jobs
- **`.github/workflows/release.yml`** — the `build` job

### Input mapping

The two actions have different APIs, so the inputs were translated:

| `actions-rs/toolchain` | `dtolnay/rust-toolchain` |
| --- | --- |
| `toolchain: stable` | moved into the action ref (`@stable`) |
| `target: <x>` | `targets: <x>` (renamed, comma-separated) |
| `profile: minimal` | dropped — `dtolnay/rust-toolchain` installs a minimal profile by default |
| `override: true` | dropped — the action always sets the installed toolchain as the default |
| `components:` | unchanged |

> Note: `actions-rs/cargo` is still in use elsewhere in these workflows and is also deprecated, but it's left untouched here to keep this change scoped to the toolchain action as requested.

https://claude.ai/code/session_01Gg83Wh91H6bkexCmhpwVBa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gg83Wh91H6bkexCmhpwVBa)_