### PR TITLE
ci: add per-target rust-cache key for matrixed test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,6 +116,8 @@ jobs:
 
       - name: cache ~/.cargo
         uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
 
       - name: install protoc
         uses: arduino/setup-protoc@v3


### PR DESCRIPTION
## Summary

The `test-platforms` job in `.github/workflows/test.yml` builds multiple Rust targets via a matrix, but its `Swatinem/rust-cache@v2` step had no `key`. Because `rust-cache` derives its key partly from the job name (which is identical across matrix entries here), all matrix entries shared one cache key and clobbered each other's caches.

This adds a per-entry `key: ${{ matrix.target }}` so each target gets its own cache.

## Notes
- The `code-quality` job is a single-entry job and already gets a unique cache key from its job name — no change needed there.
- `matrix.target` is defined for every entry of the `test-platforms` matrix, so it's a suitable unique key.

https://claude.ai/code/session_0124av2FhVQqkU25S6RrmmVR

---
_Generated by [Claude Code](https://claude.ai/code/session_0124av2FhVQqkU25S6RrmmVR)_