### PR TITLE
ci: migrate to SierraSoftworks/setup-protoc fork

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
           name: cargofile
 
       - name: install protoc
-        uses: arduino/setup-protoc@v3
+        uses: SierraSoftworks/setup-protoc@v3.0.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get install -y libdbus-1-3 libdbus-1-dev
 
       - name: install protoc
-        uses: arduino/setup-protoc@v3
+        uses: SierraSoftworks/setup-protoc@v3.0.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -120,7 +120,7 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: install protoc
-        uses: arduino/setup-protoc@v3
+        uses: SierraSoftworks/setup-protoc@v3.0.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

Replaces the deprecated `arduino/setup-protoc@v3` action with the maintained fork `SierraSoftworks/setup-protoc@v3.0.1`.

The fork is a drop-in replacement — its `action.yml` exposes the same inputs (`version`, `repo-token`, `include-pre-releases`) and outputs (`version`, `path`), so only the `uses:` reference changes; the surrounding `with:` blocks are untouched.

## Changes

- `.github/workflows/test.yml` (2 occurrences)
- `.github/workflows/release.yml` (1 occurrence)

## Verification

CI exercises the `install protoc` step on this PR — a green run confirms the fork works as a drop-in replacement.

https://claude.ai/code/session_01QfUTCb69wLXXWD3hTgyWBn

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfUTCb69wLXXWD3hTgyWBn)_