### PR TITLE
Build linux-arm64 with cross and the default feature set

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,0 @@
-[target.aarch64-unknown-linux-gnu]
-linker = "ld.lld"
-rustflags = [
-    "-C",
-    "linker=ld.lld",
-    "-C",
-    "link-arg=-L/usr/aarch64-linux-gnu/lib"
-]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,14 +107,14 @@ jobs:
             run_on: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             experimental: true
+            builder: cross
             setup: |
+              # cross builds the binary inside its own container, but the debug
+              # symbols are stripped on the host (after the Sentry upload), so we
+              # still need the aarch64 strip utility available here.
               sudo apt-get update
-              sudo apt-get install -y gcc-aarch64-linux-gnu lld
-
-              # Ensure that the libgcc
-              sudo ln -s /usr/aarch64-linux-gnu/lib/libgcc_s.so.1 /usr/aarch64-linux-gnu/lib/libgcc_s.so
+              sudo apt-get install -y binutils-aarch64-linux-gnu
             strip: aarch64-linux-gnu-strip --strip-debug
-            flags: --no-default-features
 
           # Apple MacOS builds
           - arch: amd64
@@ -163,15 +163,24 @@ jobs:
           name: cargofile
 
       - name: install protoc
+        if: matrix.builder != 'cross'
         uses: SierraSoftworks/setup-protoc@v3.0.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install Cross
+        if: matrix.builder == 'cross'
+        shell: bash
+        run: |
+          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+          cargo binstall --no-confirm cross
+
       - name: cargo build
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: build
-          args: --release --target ${{ matrix.target }} ${{ matrix.flags }}
+        run: ${{ matrix.builder || 'cargo' }} build --release --target ${{ matrix.target }} ${{ matrix.flags }}
+
+      - name: Reclaim cache ownership from cross
+        if: matrix.builder == 'cross'
+        run: sudo chown -R "$(id -u):$(id -g)" "$HOME/.cargo" target
 
       - name: Upload Debug Symbols to Sentry
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,13 +82,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
             experimental: true
             skiptests: true
-            setup: |
-              sudo apt-get update
-              sudo apt-get install -y gcc-aarch64-linux-gnu lld
-
-              # Ensure that the libgcc library can be found
-              sudo ln -s /usr/aarch64-linux-gnu/lib/libgcc_s.so.1 /usr/aarch64-linux-gnu/lib/libgcc_s.so
-            flags: --no-default-features
+            builder: cross
 
           - arch: amd64
             run_on: macos-latest
@@ -120,20 +114,29 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: install protoc
+        if: matrix.builder != 'cross'
         uses: SierraSoftworks/setup-protoc@v3.0.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Cross
+        if: matrix.builder == 'cross'
+        shell: bash
+        run: |
+          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+          cargo binstall --no-confirm cross
 
       - name: git config
         run: |
           git config --global init.defaultBranch "main"
 
       - name: cargo build
-        uses: actions-rs/cargo@v1.0.3
         if: matrix.skiptests
-        with:
-          command: build
-          args: --target ${{ matrix.target }} ${{ matrix.flags }}
+        run: ${{ matrix.builder || 'cargo' }} build --target ${{ matrix.target }} ${{ matrix.flags }}
+
+      - name: Reclaim cache ownership from cross
+        if: matrix.builder == 'cross'
+        run: sudo chown -R "$(id -u):$(id -g)" "$HOME/.cargo" target
 
       - name: cargo test
         uses: actions-rs/cargo@v1.0.3

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,14 @@
+# Configuration for cross (https://github.com/cross-rs/cross), used to build the
+# Linux arm64 (aarch64) target inside a dedicated container with the correct
+# toolchain.
+#
+# Building with the default features pulls in `keyring`, whose Linux secret
+# service backend links against libdbus via pkg-config. The cross image already
+# exports PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig/ and
+# PKG_CONFIG_ALLOW_CROSS=1, so we just need to install the arm64 development
+# package into the container before the build runs.
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt-get update && apt-get install --assume-yes libdbus-1-dev:$CROSS_DEB_ARCH pkg-config",
+]


### PR DESCRIPTION
## Summary

Switches the `aarch64-unknown-linux-gnu` (linux-arm64) build — in both the release and test workflows — from the hand-rolled host `gcc` cross-compilation setup to [cross](https://github.com/cross-rs/cross), and **enables the default features** so arm64 releases ship with keychain/auth support like every other platform (previously it was built with `--no-default-features`).

## Why

The arm64 target was built with `--no-default-features` because the default `auth` feature pulls in `keyring`, whose Linux secret-service backend links against `libdbus` via `pkg-config` — which the host-based cross-compilation setup couldn't satisfy for the target architecture. Building inside a `cross` container lets us install the arm64 `libdbus` and produce a fully-featured binary.

## Changes

- **`Cross.toml`** (new): installs `libdbus-1-dev:$CROSS_DEB_ARCH` (+ `pkg-config`) into the cross container via `pre-build`. The cross `aarch64-unknown-linux-gnu` image already exports `PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig/` and `PKG_CONFIG_ALLOW_CROSS=1`, which is exactly where `libdbus-1-dev:arm64` drops `dbus-1.pc`, so `pkg-config` resolves `dbus-1` for arm64 and the secret-service backend links correctly.
- **Enable default features for arm64**: dropped `--no-default-features` from the arm64 matrix entries.
- **Use cross**: install it via `cargo-binstall` and build with `${{ matrix.builder || 'cargo' }} build …`. The host `protoc` step is skipped for cross builds (it runs in its own container, and git-tool doesn't invoke `protoc` at build time anyway — the protobuf code in `opentelemetry-proto` is pre-generated).
- **Reclaim cache ownership after cross builds** (`sudo chown -R "$(id -u):$(id -g)" "$HOME/.cargo" target`), porting the fix from [SierraSoftworks/automate#197](https://github.com/SierraSoftworks/automate/pull/197). cross runs the compiler as root inside Docker, so this restores ownership for `Swatinem/rust-cache` (test workflow) and, in the release workflow, lets the host strip step modify the produced binary.
- **Remove `.cargo/config.toml`**: its `aarch64-unknown-linux-gnu` `ld.lld` linker override was for the old host-based approach and would otherwise be read *inside* the cross container and break linking. The release job now only needs `binutils-aarch64-linux-gnu` on the host, for stripping debug symbols after the Sentry upload.

## Validation

Container image pulls are blocked in the authoring sandbox, but the critical assumption — that `libdbus-1-dev:arm64` + the cross image's pre-set `PKG_CONFIG_PATH` lets `pkg-config` resolve `dbus-1` for arm64 — was validated end-to-end by replicating the cross image's exact environment:

- `dbus-1.pc` installs to `/usr/lib/aarch64-linux-gnu/pkgconfig/dbus-1.pc` (== the image's `PKG_CONFIG_PATH`)
- with `PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig/ PKG_CONFIG_ALLOW_CROSS=1`, `pkg-config --exists dbus-1` succeeds and reports:
  - cflags: `-I/usr/include/dbus-1.0 -I/usr/lib/aarch64-linux-gnu/dbus-1.0/include`
  - libs: `-L/usr/lib/aarch64-linux-gnu -ldbus-1` (the arm64 tree)

The full cross build runs in CI on this PR.

https://claude.ai/code/session_01324cTAzt1xZUgn9VJQgXYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01324cTAzt1xZUgn9VJQgXYW)_