### PR TITLE
fix(telemetry): only report system-caused failures to Sentry

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -65,14 +65,7 @@ where {
                 });
 
                 info!("Resuming update in phase {}", state.phase);
-                manager.resume(&state).await.inspect_err(|e| {
-                    // Only report system-caused failures to Sentry. User-caused
-                    // errors are the result of invalid input or environment state
-                    // and shouldn't be recorded as telemetry.
-                    if e.is(human_errors::Kind::System) {
-                        sentry::capture_error(&e);
-                    }
-                })?
+                manager.resume(&state).await.inspect_err(report_system_failure)?
             }
             None => false,
         };
@@ -178,6 +171,15 @@ where {
     }
 }
 
+/// Reports a failure to Sentry, but only when it was system-caused. User-caused
+/// errors are the result of invalid input or environment state and shouldn't be
+/// recorded as telemetry, so they are deliberately ignored here.
+fn report_system_failure(error: &human_errors::Error) {
+    if error.is(human_errors::Kind::System) {
+        sentry::capture_error(error);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::console::MockConsoleProvider;
@@ -217,5 +219,71 @@ mod tests {
         });
 
         assert!(has_version, "the output should contain a list of versions");
+    }
+
+    #[test]
+    fn report_user_failure_is_not_sent_to_sentry() {
+        let events = sentry::test::with_captured_events(|| {
+            report_system_failure(&human_errors::user(
+                "You did something that wasn't quite right.",
+                &["Try again with valid input."],
+            ));
+        });
+
+        assert!(
+            events.is_empty(),
+            "user-caused failures should not be reported to Sentry"
+        );
+    }
+
+    #[test]
+    fn report_system_failure_is_sent_to_sentry() {
+        let events = sentry::test::with_captured_events(|| {
+            report_system_failure(&human_errors::system(
+                "Something went wrong on our end.",
+                &["Please report this issue to us on GitHub."],
+            ));
+        });
+
+        assert_eq!(
+            events.len(),
+            1,
+            "system-caused failures should be reported to Sentry"
+        );
+    }
+
+    #[test]
+    fn run_resume_reports_only_system_failures() {
+        // Resuming an update whose state is missing the temporary application
+        // path fails with a system-caused error, which should be reported to
+        // Sentry through the `inspect_err(report_system_failure)` path in `run`.
+        let events = sentry::test::with_captured_events(|| {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .expect("we should be able to build a Tokio runtime");
+
+            rt.block_on(async {
+                let console = Arc::new(MockConsoleProvider::new());
+                let core = Core::builder()
+                    .with_default_config()
+                    .with_console(console.clone())
+                    .build();
+
+                let cmd = UpdateCommand {};
+                let args = cmd
+                    .app()
+                    .get_matches_from(vec!["update", "--state", r#"{"phase":"cleanup"}"#]);
+
+                cmd.run(&core, &args).await.expect_err(
+                    "resuming an update without a temporary application path should fail",
+                );
+            });
+        });
+
+        assert_eq!(
+            events.len(),
+            1,
+            "the system-caused resume failure should be reported to Sentry"
+        );
     }
 }

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -65,7 +65,10 @@ where {
                 });
 
                 info!("Resuming update in phase {}", state.phase);
-                manager.resume(&state).await.inspect_err(report_system_failure)?
+                manager
+                    .resume(&state)
+                    .await
+                    .inspect_err(report_system_failure)?
             }
             None => false,
         };
@@ -270,9 +273,9 @@ mod tests {
                     .build();
 
                 let cmd = UpdateCommand {};
-                let args = cmd
-                    .app()
-                    .get_matches_from(vec!["update", "--state", r#"{"phase":"cleanup"}"#]);
+                let args =
+                    cmd.app()
+                        .get_matches_from(vec!["update", "--state", r#"{"phase":"cleanup"}"#]);
 
                 cmd.run(&core, &args).await.expect_err(
                     "resuming an update without a temporary application path should fail",

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -65,10 +65,7 @@ where {
                 });
 
                 info!("Resuming update in phase {}", state.phase);
-                manager
-                    .resume(&state)
-                    .await
-                    .inspect_err(report_system_failure)?
+                manager.resume(&state).await?
             }
             None => false,
         };
@@ -174,15 +171,6 @@ where {
     }
 }
 
-/// Reports a failure to Sentry, but only when it was system-caused. User-caused
-/// errors are the result of invalid input or environment state and shouldn't be
-/// recorded as telemetry, so they are deliberately ignored here.
-fn report_system_failure(error: &human_errors::Error) {
-    if error.is(human_errors::Kind::System) {
-        sentry::capture_error(error);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::console::MockConsoleProvider;
@@ -225,41 +213,11 @@ mod tests {
     }
 
     #[test]
-    fn report_user_failure_is_not_sent_to_sentry() {
-        let events = sentry::test::with_captured_events(|| {
-            report_system_failure(&human_errors::user(
-                "You did something that wasn't quite right.",
-                &["Try again with valid input."],
-            ));
-        });
-
-        assert!(
-            events.is_empty(),
-            "user-caused failures should not be reported to Sentry"
-        );
-    }
-
-    #[test]
-    fn report_system_failure_is_sent_to_sentry() {
-        let events = sentry::test::with_captured_events(|| {
-            report_system_failure(&human_errors::system(
-                "Something went wrong on our end.",
-                &["Please report this issue to us on GitHub."],
-            ));
-        });
-
-        assert_eq!(
-            events.len(),
-            1,
-            "system-caused failures should be reported to Sentry"
-        );
-    }
-
-    #[test]
-    fn run_resume_reports_only_system_failures() {
-        // Resuming an update whose state is missing the temporary application
-        // path fails with a system-caused error, which should be reported to
-        // Sentry through the `inspect_err(report_system_failure)` path in `run`.
+    fn run_resume_bubbles_up_failures_without_reporting() {
+        // The update command shouldn't report failures to Sentry itself; it
+        // bubbles them up so that `main` decides what to record (only
+        // system-caused errors are). This keeps user-caused errors out of
+        // telemetry and avoids double-reporting system-caused ones.
         let events = sentry::test::with_captured_events(|| {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .build()
@@ -283,10 +241,9 @@ mod tests {
             });
         });
 
-        assert_eq!(
-            events.len(),
-            1,
-            "the system-caused resume failure should be reported to Sentry"
+        assert!(
+            events.is_empty(),
+            "the update command should not report failures to Sentry directly"
         );
     }
 }

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -66,7 +66,12 @@ where {
 
                 info!("Resuming update in phase {}", state.phase);
                 manager.resume(&state).await.inspect_err(|e| {
-                    sentry::capture_error(&e);
+                    // Only report system-caused failures to Sentry. User-caused
+                    // errors are the result of invalid input or environment state
+                    // and shouldn't be recorded as telemetry.
+                    if e.is(human_errors::Kind::System) {
+                        sentry::capture_error(&e);
+                    }
                 })?
             }
             None => false,


### PR DESCRIPTION
## Problem

User-caused errors were being recorded in Sentry when telemetry is enabled, even though the policy is to only capture system-caused failures.

The main error handler in `src/main.rs` already filters correctly:

```rust
if err.is(human_errors::Kind::System) {
    session.record_error(&err);
}
```

However, the `update` command captured **every** error from `UpdateManager::resume` unconditionally:

```rust
manager.resume(&state).await.inspect_err(|e| {
    sentry::capture_error(&e);
})?
```

`resume` (and the functions it calls) can return user-caused errors — e.g. `wrap_user_err` / `human_errors::user` / `human_errors::wrap_user` in `src/update/manager.rs` (lines 84, 92, 115, 188, 204) for things like permission issues or invalid environment state. These were being sent to Sentry as telemetry noise.

## Fix

Guard the `update` capture site with the same `is(Kind::System)` check used by the main error handler, so only system-caused failures are reported to Sentry. The two `capture_message(..., Level::Info)` calls in the update flow are intentional lifecycle events (not failures) and are left unchanged.

This was the only remaining unguarded error-capture path — verified by auditing every `sentry::capture_*` / `record_error` call in the codebase.

## Testing

`cargo check --no-default-features --features telemetry` passes (the `auth`/`keyring` feature can't build in this environment due to a missing `dbus-1` system library, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018zVkMxJY3ddLM5NHrvNwLR)_