### PR TITLE
ci: publish releases to the Homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           overwrite: "true"
 
+      - name: Update Homebrew Tap
+        uses: SierraSoftworks/actions-tap@v1
+        with:
+          app-id: ${{ secrets.TAP_APP_ID }}
+          private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+
       # - uses: anchore/sbom-action@v0
       #   with:
       #     file: "target/${{ matrix.target }}/release/git-tool${{ matrix.extension }}"


### PR DESCRIPTION
After uploading each platform binary, call SierraSoftworks/actions-tap to incrementally update the git-tool formula in SierraSoftworks/homebrew-tap. Each matrix job updates only its own platform block (windows is skipped), so no fan-in job is needed. Uses the org-level tap publisher GitHub App.