### PR TITLE
ci: install sentry-cli via npm instead of setup-sentry-cli action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ jobs:
       id-token: write
       contents: read
 
+    env:
+      SENTRY_ORG: sierra-softworks
+      SENTRY_PROJECT: git-tool
+
     steps:
       - name: get secrets - sentry
         uses: hashicorp/vault-action@v4.0.0
@@ -27,12 +31,8 @@ jobs:
           secrets: |
             secrets/data/repos/SierraSoftworks/git-tool/sentry token | SENTRY_AUTH_TOKEN;
 
-      - name: Setup Sentry CLI
-        uses: mathieu-bour/setup-sentry-cli@v2.0.0
-        with:
-          token: ${{ env.SENTRY_AUTH_TOKEN }}
-          organization: sierra-softworks
-          project: git-tool
+      - name: Install Sentry CLI
+        run: npm install -g @sentry/cli
 
       - name: Check out code
         uses: actions/checkout@v7
@@ -72,6 +72,10 @@ jobs:
       id-token: write
       contents: write
       attestations: write
+
+    env:
+      SENTRY_ORG: sierra-softworks
+      SENTRY_PROJECT: git-tool
 
     needs:
       - version
@@ -147,12 +151,8 @@ jobs:
           secrets: |
             secrets/data/repos/SierraSoftworks/git-tool/sentry token | SENTRY_AUTH_TOKEN;
 
-      - name: Setup Sentry CLI
-        uses: mathieu-bour/setup-sentry-cli@v2.0.0
-        with:
-          token: ${{ env.SENTRY_AUTH_TOKEN }}
-          organization: sierra-softworks
-          project: git-tool
+      - name: Install Sentry CLI
+        run: npm install -g @sentry/cli
 
       - name: Check out code
         uses: actions/checkout@v7
@@ -235,6 +235,10 @@ jobs:
       id-token: write
       contents: read
 
+    env:
+      SENTRY_ORG: sierra-softworks
+      SENTRY_PROJECT: git-tool
+
     steps:
       - name: get secrets - sentry
         uses: hashicorp/vault-action@v4.0.0
@@ -247,12 +251,8 @@ jobs:
           secrets: |
             secrets/data/repos/SierraSoftworks/git-tool/sentry token | SENTRY_AUTH_TOKEN;
 
-      - name: Setup Sentry CLI
-        uses: mathieu-bour/setup-sentry-cli@v2.0.0
-        with:
-          token: ${{ env.SENTRY_AUTH_TOKEN }}
-          organization: sierra-softworks
-          project: git-tool
+      - name: Install Sentry CLI
+        run: npm install -g @sentry/cli
 
       - name: Finalize Sentry Release
         run: |


### PR DESCRIPTION
## Summary

The `mathieu-bour/setup-sentry-cli` action hasn't been updated in a while. This switches to installing the Sentry CLI with `npm install -g @sentry/cli`, as recommended in the [Sentry CLI docs](https://docs.sentry.io/cli/installation/).

## Changes

- Replaced the `Setup Sentry CLI` step (`mathieu-bour/setup-sentry-cli@v2.0.0`) with an `Install Sentry CLI` step running `npm install -g @sentry/cli` in all three jobs (`version`, `build`, `sentry`).
- The old action also configured the organization/project. Since the bare `sentry-cli` commands (`releases new`, `set-commits`, `finalize`) rely on that configuration, the org/project are now provided via job-level `SENTRY_ORG` / `SENTRY_PROJECT` environment variables.
- The `SENTRY_AUTH_TOKEN` continues to be supplied by the existing Vault step and is picked up automatically by the CLI from the environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzHJRG3peA6fFvCG6U6o48)_