### PR TITLE
ci: pass github-token to the Homebrew tap update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,7 @@ jobs:
         with:
           app-id: ${{ secrets.TAP_APP_ID }}
           private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
 


### PR DESCRIPTION
Lets actions-tap read the source repository metadata (description, homepage, license) authenticated, avoiding the unauthenticated GitHub API rate limit that was returning 403 on shared runners.