### PR TITLE
ci: update the tap once, after all builds, with versioned aliases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,15 +198,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           overwrite: "true"
 
-      - name: Update Homebrew Tap
-        uses: SierraSoftworks/actions-tap@v1
-        with:
-          app-id: ${{ secrets.TAP_APP_ID }}
-          private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          os: ${{ matrix.os }}
-          arch: ${{ matrix.arch }}
-
       # - uses: anchore/sbom-action@v0
       #   with:
       #     file: "target/${{ matrix.target }}/release/git-tool${{ matrix.extension }}"
@@ -220,6 +211,21 @@ jobs:
       #     subject-name: "git-tool-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.extension }}"
       #     subject-path: "target/${{ matrix.target }}/release/git-tool${{ matrix.extension }}"
       #     sbom-path: 'sbom.spdx.json'
+
+  tap:
+    name: Update Homebrew Tap
+    runs-on: ubuntu-latest
+    needs:
+      - build
+
+    steps:
+      - name: Update Homebrew Tap
+        uses: SierraSoftworks/actions-tap@v1
+        with:
+          app-id: ${{ secrets.TAP_APP_ID }}
+          private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          aliases: major minor
 
   sentry:
     name: Finalize Release


### PR DESCRIPTION
Replace the per-matrix actions-tap step with a single tap job that runs after the build matrix. The action then links all platforms at once, so the formula is never partially complete during a release. Also publish major/minor versioned aliases (git-tool@3, git-tool@3.11).