### PR TITLE
docs: document Homebrew tap installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Git Tool is a powerful tool for managing your Git repositories, storing them in
 a consistent folder structure and simplifying access when you need it. The best
 place to get started is by reading our [documentation](https://git-tool.sierrasoftworks.com).
 
+## Installation
+
+Install with [Homebrew](https://brew.sh):
+
+```sh
+brew install sierrasoftworks/tap/git-tool
+```
+
 ## Features
 
 - **Quickly open repositories** whether they are already cloned locally or not, using your favourite Git services and a concise folder structure.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -16,6 +16,14 @@ Once you have downloaded the latest Git-Tool executable, rename it to `git-tool`
 On Linux and MacOS machines, you may need to use `chmod +x git-tool` to mark the program as executable.
 :::
 
+### Using Homebrew
+If you're using [Homebrew](https://brew.sh) on MacOS or Linux, you can install Git-Tool from
+the Sierra Softworks tap.
+
+```sh
+brew install sierrasoftworks/tap/git-tool
+```
+
 ### Using Cargo
 If you'd prefer, or if we don't (yet) provide pre-built releases for your platform, you can build
 Git-Tool yourself using `cargo`. Note that you'll need to have [rust installed](https://www.rust-lang.org/tools/install)


### PR DESCRIPTION
Adds a concise Homebrew installation section to the README and documentation site, pointing users at the Sierra Softworks tap:

    brew install sierrasoftworks/tap/git-tool

Part of the Homebrew tap rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
