### PR TITLE
Replace Umami analytics with the new Analytics battery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -230,7 +230,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -712,7 +712,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -777,7 +777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1492,7 +1492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1665,7 +1665,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2045,7 +2045,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2373,7 +2373,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2432,7 +2432,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2759,7 +2759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2830,7 +2830,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3201,10 +3201,11 @@ dependencies = [
 [[package]]
 name = "tracing-batteries"
 version = "0.1.0"
-source = "git+https://github.com/sierrasoftworks/tracing-batteries-rs.git#89854ad16dde3c4af6b9fc6e87ffa0d64b158fc1"
+source = "git+https://github.com/sierrasoftworks/tracing-batteries-rs.git#cf35de7fad4e013391383219abed2f4d58abe963"
 dependencies = [
  "chrono",
  "hex",
+ "iana-time-zone",
  "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
@@ -3644,7 +3645,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ tokio = { version = "1.52", features = [
     "signal",
 ] }
 tracing = { version = "0.1.43", features = ["log"] }
-tracing-batteries = { git = "https://github.com/sierrasoftworks/tracing-batteries-rs.git", features = ["umami", "opentelemetry", "sentry"] }
+tracing-batteries = { git = "https://github.com/sierrasoftworks/tracing-batteries-rs.git", features = ["analytics", "opentelemetry", "sentry"] }
 # Self-update machinery (extracted from this project). The `opentelemetry`
 # feature emits tracing spans for the update and propagates the trace context
 # across the three relaunch phases via the update state.

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,7 +170,7 @@ async fn host(app: clap::Command, session: &TelemetrySession) -> Result<i32, hum
 
     #[cfg(feature = "telemetry")]
     let _page = session.record_new_page(format!(
-        "/.app/{}",
+        "/{}",
         matches.subcommand_name().unwrap_or_default()
     ));
 

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -33,13 +33,9 @@ pub fn setup() -> tracing_batteries::Session {
                 "vdf1xcENEju8V0d8ffQq2Y",
             ),
         )
-        .with_battery(
-            tracing_batteries::Umami::new(
-                "https://analytics.sierrasoftworks.com",
-                "a816dd16-8bf4-4433-b04f-9d73a6751f84",
-            )
-            .with_initial_page("/.app/"),
-        )
+        .with_battery(tracing_batteries::Analytics::new(
+            "https://analytics.sierrasoftworks.com",
+        ))
 }
 
 #[cfg(not(feature = "telemetry"))]


### PR DESCRIPTION
## Summary

The self-hosted Umami analytics deployment at `https://analytics.sierrasoftworks.com` has been retired in favor of a new self-hosted analytics server. `tracing-batteries-rs` now ships an `Analytics` battery (behind the `analytics` cargo feature) that replaces the old `Umami` battery (`umami` feature). The new battery takes only a server URL (no website ID) and no longer uses the `/.app/` page-prefix convention — it defaults to page `/` on a virtual hostname `{service}.app`.

This PR migrates git-tool to the new integration:

- `Cargo.toml`: switch the `tracing-batteries` feature flag from `umami` to `analytics`.
- `src/telemetry/mod.rs`: replace `tracing_batteries::Umami::new(url, website_id).with_initial_page("/.app/")` with `tracing_batteries::Analytics::new(url)`.
- `src/main.rs`: drop the retired `/.app/` page-path prefix when recording page views for subcommands (e.g. `/clone` instead of `/.app/clone`).
- `Cargo.lock`: bump the `tracing-batteries` git dependency pin to the latest `main`.

## Test plan

- `cargo check` (default features, which include `telemetry`) — passes
- `cargo check --features telemetry` — passes
- `cargo check --no-default-features --features telemetry` — passes
- `cargo test --features pure-tests` — 261 passed, 0 failed (network-dependent tests excluded, as documented in `Cargo.toml`)
- `cargo clippy --all-targets` — only 2 pre-existing warnings, unrelated to this change (`src/commands/prune.rs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NutKW958x2VF9rVagycenv

---
_Generated by [Claude Code](https://claude.ai/code/session_01NutKW958x2VF9rVagycenv)_