### PR TITLE
feat: Record privacy-preserving analytics events for key operations

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: verify
+description: Build and drive the git-tool CLI to verify a change end-to-end, including observing telemetry events locally.
+---
+
+# Verifying git-tool changes
+
+## Build & run
+
+```bash
+cargo build                        # binary at target/debug/git-tool
+GITTOOL_CONFIG=<config.yml> ./target/debug/git-tool <command>
+```
+
+Minimal test config (put dev/scratchpads under a temp dir):
+
+```yaml
+directory: /tmp/gt-verify/dev
+scratchpads: /tmp/gt-verify/scratchpads
+features:
+  telemetry: true          # off by default; required for event delivery
+  check_for_updates: false # avoids GitHub API calls on `gt open`
+apps:
+  - name: shell
+    command: "true"        # overrides default shell; exits instantly
+```
+
+Useful flows: `gt list` (resolve many), `gt scratch` (new-folder task + app
+launch/exit), `gt update --state '<garbage>'` (error path, exits 1).
+
+## Observing telemetry events
+
+The analytics endpoint is hard-coded in `src/telemetry/mod.rs`. Temporarily
+point `tracing_batteries::Analytics::new(...)` at `http://127.0.0.1:8377`,
+run a tiny HTTP listener that dumps POST bodies (`/track/hit`,
+`/track/exception`), drive commands, and read the captured JSON. **Revert the
+URL afterwards.** Events appear as `"e":"custom"` hits with the event name in
+`"n"` and properties in `"d"`.
+
+## Gotchas
+
+- `cargo test` fails on every test that creates a git commit when the global
+  git config enables SSH commit signing and no signing agent is reachable
+  (sandboxed shells): commits hang ~60s then exit 128. Fix by overriding for
+  the run:
+
+  ```bash
+  GIT_CONFIG_GLOBAL=<neutral-gitconfig> GIT_CONFIG_SYSTEM=/dev/null cargo test
+  ```
+
+  where the neutral config sets `user.name`/`user.email`,
+  `commit.gpgsign = false` and `init.defaultBranch = main`.
+- The ignore/gitignore network tests are flaky under parallel `cargo test`;
+  they pass when run isolated.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -230,7 +230,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -712,7 +712,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -777,7 +777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1492,7 +1492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1665,7 +1665,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2045,7 +2045,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2373,7 +2373,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2432,7 +2432,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2759,7 +2759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2830,7 +2830,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3201,7 +3201,7 @@ dependencies = [
 [[package]]
 name = "tracing-batteries"
 version = "0.1.0"
-source = "git+https://github.com/sierrasoftworks/tracing-batteries-rs.git#e1f168e57bb74c146405cf74d6120902fe677926"
+source = "git+https://github.com/sierrasoftworks/tracing-batteries-rs.git#92894c3dbfc16fe2d1c4dc7b7023e12f3b3c88be"
 dependencies = [
  "chrono",
  "hex",
@@ -3645,7 +3645,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -76,7 +76,7 @@ impl CommandRunnable for RenameCommand {
         .await?;
 
         // Don't forget to update the remote URL to match the new repository name
-        GitRemote { name: "origin" }
+        sequence![GitRemote { name: "origin" }]
             .apply_repo(core, &new_repo)
             .await?;
 

--- a/src/commands/scratch.rs
+++ b/src/commands/scratch.rs
@@ -39,8 +39,9 @@ You may also append any number of KEY=VALUE tokens to override environment varia
         let scratchpad = &parsed.target;
 
         if !scratchpad.exists() {
-            let task = tasks::NewFolder {};
-            task.apply_scratchpad(core, scratchpad).await?;
+            sequence![tasks::NewFolder {}]
+                .apply_scratchpad(core, scratchpad)
+                .await?;
         }
 
         let status = core.launcher().run(&app, scratchpad).await?;

--- a/src/commands/switch.rs
+++ b/src/commands/switch.rs
@@ -44,12 +44,12 @@ impl CommandRunnable for SwitchCommand {
 
         match matches.get_one::<String>("branch") {
             Some(branch) => {
-                let task = GitSwitch {
+                sequence![GitSwitch {
                     branch: branch.to_string(),
                     create_if_missing: !matches.get_flag("no-create"),
-                };
-
-                task.apply_repo(core, &repo).await?;
+                }]
+                .apply_repo(core, &repo)
+                .await?;
             }
             None => {
                 let branches = git::git_branches(&repo.get_path()).await?;

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -44,7 +44,28 @@ impl CommandRunnable for UpdateCommand {
         // context, so the phases stay on one distributed trace).
         if let Some(state) = matches.get_one::<String>("state") {
             info!("Resuming an in-progress update.");
-            manager.resume_from_arg(state).await?;
+
+            // The reported phase comes from deserializing update-rs's own state
+            // type, so its value is one of that crate's hard-coded phase names —
+            // never free-form input.
+            let phase = serde_json::from_str::<update_rs::UpdateState>(state)
+                .map(|state| state.phase.to_string())
+                .unwrap_or_else(|_| "invalid".to_string());
+
+            let result = manager.resume_from_arg(state).await;
+            core.analytics().record_event(
+                format!("update::{phase}"),
+                [(
+                    "status",
+                    if result.is_ok() {
+                        "succeeded".to_string()
+                    } else {
+                        "failed".to_string()
+                    },
+                )],
+            );
+            result?;
+
             return Ok(0);
         }
 
@@ -88,9 +109,34 @@ impl CommandRunnable for UpdateCommand {
                     &format!("Starting Update to {}", release.id),
                     sentry::Level::Info,
                 );
+
+                // Release versions are public information from this project's own
+                // GitHub releases, making them safe to include in telemetry events.
+                core.analytics().record_event(
+                    "update::started",
+                    [
+                        ("to_version", release.id.clone()),
+                        ("prerelease", release.prerelease.to_string()),
+                    ],
+                );
+
                 writeln!(core.output(), "Downloading update {}...", &release.id)
                     .to_human_error()?;
-                if manager.update(release).await? {
+
+                let result = manager.update(release).await;
+                core.analytics().record_event(
+                    "update::prepare",
+                    [(
+                        "status",
+                        if result.is_ok() {
+                            "succeeded".to_string()
+                        } else {
+                            "failed".to_string()
+                        },
+                    )],
+                );
+
+                if result? {
                     writeln!(
                         core.output(),
                         "Shutting down to complete the update operation."

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -97,12 +97,12 @@ Worktrees are created within the worktree directory configured in your config fi
         let worktree: Worktree = core.resolve((&repo, branch))?;
         let worktree_path = worktree.path();
 
-        GitWorktree {
+        sequence![GitWorktree {
             path: worktree_path.clone(),
             branch: branch.to_string(),
             create_if_missing: !no_create,
             base: base.cloned(),
-        }
+        }]
         .apply_repo(core, &repo)
         .await?;
 

--- a/src/engine/analytics.rs
+++ b/src/engine/analytics.rs
@@ -1,0 +1,77 @@
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use tracing_batteries::Session;
+
+/// A shareable handle to the application's telemetry [`Session`] through which
+/// the engine records usage events for key operations (tasks, resolutions, web
+/// requests, application launches, ...).
+///
+/// The handle is attached to a [`super::Core`] when the application starts and is
+/// reachable anywhere the core is through [`super::Core::analytics`]. When telemetry
+/// is disabled at compile time — and within tests, where no session exists — the
+/// handle is simply empty and recording an event is a no-op. At runtime, delivery
+/// is additionally gated by the session's own enabled flag, which honours the
+/// user's `telemetry` feature flag in their configuration file.
+#[derive(Clone, Default)]
+pub struct Analytics {
+    session: Option<Arc<Session>>,
+}
+
+impl Analytics {
+    /// Creates a handle which records events through the provided telemetry session.
+    #[cfg_attr(not(feature = "telemetry"), allow(dead_code))]
+    pub fn new(session: Arc<Session>) -> Self {
+        Self {
+            session: Some(session),
+        }
+    }
+
+    /// Creates a handle which records nothing. This is the default for cores built
+    /// without an explicit session (tests, telemetry-less builds).
+    pub fn disabled() -> Self {
+        Self::default()
+    }
+
+    /// Records a usage event against the telemetry session.
+    ///
+    /// Event names identify the operation which was performed and are namespaced
+    /// with `::` (for example `commands::list` or `tasks::git-clone`) so that the
+    /// events of a session trace group naturally and read intuitively.
+    ///
+    /// Events **must** be privacy preserving: every segment of the event name has
+    /// to come from a hard-coded set (command names, [`crate::tasks::Task::name`]
+    /// values, whitelisted phases, ...), property keys are forced to be literals by
+    /// this signature, and property *values* must never carry information which
+    /// could identify the user or their work — no hostnames, repository or
+    /// application names, paths, branch names, or anything else derived from user
+    /// input or configuration. Safe values are hard-coded enumerations and data
+    /// about the binary itself: exit codes, counts, booleans, release versions,
+    /// and the like.
+    pub fn record_event<N, P>(&self, name: N, properties: P)
+    where
+        N: Into<Cow<'static, str>>,
+        P: IntoIterator<Item = (&'static str, String)>,
+    {
+        if let Some(session) = &self.session {
+            session.record_event(
+                name,
+                properties
+                    .into_iter()
+                    .map(|(key, value)| (key.to_string(), value))
+                    .collect(),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_handle_is_a_noop() {
+        let analytics = Analytics::disabled();
+        analytics.record_event("test.event", [("key", "value".to_string())]);
+    }
+}

--- a/src/engine/builder.rs
+++ b/src/engine/builder.rs
@@ -1,7 +1,7 @@
 use crate::console::{self, ConsoleProvider};
 
 use super::resolve::{ResolverBackend, TrueResolver};
-use super::{Config, Core, HttpClient, KeyChain, Launcher, auth, http, launcher};
+use super::{Analytics, Config, Core, HttpClient, KeyChain, Launcher, auth, http, launcher};
 
 #[cfg(test)]
 use super::resolve::MockResolver;
@@ -28,6 +28,7 @@ impl CoreBuilderWithoutConfig {
             keychain: auth::keychain(),
             http_client: http::client(),
             console: console::default(),
+            analytics: Analytics::disabled(),
             config,
         }
     }
@@ -63,6 +64,7 @@ pub struct CoreBuilderWithConfig {
     pub(super) resolver: ResolverBackend,
     pub(super) keychain: Arc<dyn KeyChain + Send + Sync>,
     pub(super) http_client: Arc<dyn HttpClient + Send + Sync>,
+    pub(super) analytics: Analytics,
 }
 
 impl From<CoreBuilderWithConfig> for Core {
@@ -74,14 +76,29 @@ impl From<CoreBuilderWithConfig> for Core {
 #[allow(dead_code)]
 impl CoreBuilderWithConfig {
     pub fn build(self) -> Core {
+        // The launcher and HTTP client are wrapped here (rather than where they are
+        // constructed) so that every implementation — including the mocks used in
+        // tests — reports its telemetry events consistently, regardless of the order
+        // in which the builder methods were called.
         Core {
             config: self.config,
-            launcher: self.launcher,
+            launcher: Arc::new(launcher::InstrumentedLauncher {
+                inner: self.launcher,
+                analytics: self.analytics.clone(),
+            }),
             resolver: self.resolver,
             keychain: self.keychain,
-            http_client: self.http_client,
+            http_client: Arc::new(http::InstrumentedHttpClient {
+                inner: self.http_client,
+                analytics: self.analytics.clone(),
+            }),
             console: self.console,
+            analytics: self.analytics,
         }
+    }
+
+    pub fn with_analytics(self, analytics: Analytics) -> Self {
+        Self { analytics, ..self }
     }
 
     pub fn with_console(self, console: Arc<dyn ConsoleProvider + Send + Sync>) -> Self {

--- a/src/engine/http.rs
+++ b/src/engine/http.rs
@@ -49,6 +49,50 @@ struct TrueHttpClient {
     client: Client,
 }
 
+/// Wraps an [`HttpClient`] so that every request records a privacy-preserving
+/// telemetry event describing the request's method and response status — never
+/// its URL, which may identify the service (and repository) being accessed.
+///
+/// Requests made through [`HttpClient::reqwest_client`] bypass this wrapper; the
+/// call sites which need a raw client (such as the self-updater) record their own
+/// higher-level events instead.
+pub(super) struct InstrumentedHttpClient {
+    pub(super) inner: Arc<dyn HttpClient + Send + Sync>,
+    pub(super) analytics: super::Analytics,
+}
+
+#[async_trait::async_trait]
+impl HttpClient for InstrumentedHttpClient {
+    async fn request(&self, req: Request) -> Result<Response, human_errors::Error> {
+        let method = req.method().to_string();
+
+        let result = self.inner.request(req).await;
+
+        let mut properties = vec![
+            ("method", method),
+            (
+                "status",
+                if result.is_ok() {
+                    "succeeded".to_string()
+                } else {
+                    "failed".to_string()
+                },
+            ),
+        ];
+        if let Ok(response) = &result {
+            properties.push(("code", response.status().as_u16().to_string()));
+        }
+
+        self.analytics.record_event("http::request", properties);
+
+        result
+    }
+
+    fn reqwest_client(&self) -> Client {
+        self.inner.reqwest_client()
+    }
+}
+
 impl std::fmt::Debug for dyn HttpClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "HttpClient")

--- a/src/engine/launcher.rs
+++ b/src/engine/launcher.rs
@@ -28,6 +28,43 @@ pub fn launcher(config: Arc<Config>) -> Arc<dyn Launcher + Send + Sync> {
     Arc::new(TrueLauncher { config })
 }
 
+/// Wraps a [`Launcher`] so that every application launch records privacy-preserving
+/// telemetry events: that an application was launched, and how it exited. Nothing
+/// about the application itself (its name, command, arguments or target) is reported.
+pub(super) struct InstrumentedLauncher {
+    pub(super) inner: Arc<dyn Launcher + Send + Sync>,
+    pub(super) analytics: super::Analytics,
+}
+
+#[async_trait::async_trait]
+impl Launcher for InstrumentedLauncher {
+    async fn run(
+        &self,
+        a: &app::App,
+        t: &(dyn Target + Send + Sync),
+    ) -> Result<i32, human_errors::Error> {
+        self.analytics
+            .record_event("apps::launched", std::iter::empty());
+
+        let result = self.inner.run(a, t).await;
+
+        match &result {
+            Ok(status) => self.analytics.record_event(
+                "apps::exited",
+                [
+                    ("status", "succeeded".to_string()),
+                    ("exit_code", status.to_string()),
+                ],
+            ),
+            Err(_) => self
+                .analytics
+                .record_event("apps::exited", [("status", "failed".to_string())]),
+        }
+
+        result
+    }
+}
+
 struct TrueLauncher {
     config: Arc<Config>,
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,3 +1,4 @@
+mod analytics;
 mod app;
 mod auth;
 mod branch;
@@ -27,6 +28,7 @@ use crate::console::ConsoleProvider;
 pub use human_errors::Error;
 
 pub use self::http::HttpClient;
+pub use analytics::Analytics;
 pub use app::App;
 pub use auth::KeyChain;
 pub use branch::Branch;
@@ -50,6 +52,7 @@ pub struct Core {
     resolver: ResolverBackend,
     keychain: Arc<dyn KeyChain + Send + Sync>,
     http_client: Arc<dyn HttpClient + Send + Sync>,
+    analytics: Analytics,
 }
 
 impl Core {
@@ -83,5 +86,9 @@ impl Core {
 
     pub fn http_client(&self) -> &(dyn HttpClient + Send + Sync) {
         self.http_client.as_ref()
+    }
+
+    pub fn analytics(&self) -> &Analytics {
+        &self.analytics
     }
 }

--- a/src/engine/resolve/app.rs
+++ b/src/engine/resolve/app.rs
@@ -4,26 +4,32 @@ use crate::engine::{App, Core};
 /// Resolves the default application (the first one in the configuration file).
 impl Resolver<(), App> for Core {
     fn resolve(&self, _source: ()) -> Result<App, human_errors::Error> {
-        self.config().get_default_app().cloned().ok_or_else(|| {
+        let result = self.config().get_default_app().cloned().ok_or_else(|| {
             human_errors::user(
                 "No default application available.",
                 &["Make sure that you add an app to your config file using 'git-tool config add apps/bash' or similar."],
             )
-        })
+        });
+
+        self.record_resolve_event::<App>(result.is_ok(), "one");
+        result
     }
 }
 
 /// Resolves an application by its configured name.
 impl Resolver<&str, App> for Core {
     fn resolve(&self, source: &str) -> Result<App, human_errors::Error> {
-        self.config().get_app(source).cloned().ok_or_else(|| {
+        let result = self.config().get_app(source).cloned().ok_or_else(|| {
             human_errors::user(
                 format!(
                     "Could not find application with name '{source}'. Make sure that you are using an application which is present in your configuration file, or install it with 'git-tool config add apps/{source}'."
                 ),
                 &["Check your configuration file for available applications."],
             )
-        })
+        });
+
+        self.record_resolve_event::<App>(result.is_ok(), "one");
+        result
     }
 }
 

--- a/src/engine/resolve/mod.rs
+++ b/src/engine/resolve/mod.rs
@@ -24,7 +24,7 @@ mod worktree;
 
 use std::sync::Arc;
 
-use super::Config;
+use super::{Config, Core};
 
 #[cfg(test)]
 pub use mock::MockResolver;
@@ -65,6 +65,91 @@ impl TrueResolver {
     pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
+}
+
+impl Core {
+    /// Forwards a resolution to the active backend, recording a telemetry event for
+    /// it. The [`Resolver`] implementations on [`Core`] which are substitutable in
+    /// tests route through this rather than calling the backend directly.
+    #[cfg(not(test))]
+    pub(crate) fn resolve_with_events<S, T>(&self, source: S) -> Result<T, human_errors::Error>
+    where
+        TrueResolver: Resolver<S, T>,
+    {
+        let result = self.resolver.resolve_with(source);
+        self.record_resolve_event::<T>(result.is_ok(), "one");
+        result
+    }
+
+    #[cfg(test)]
+    pub(crate) fn resolve_with_events<S, T>(&self, source: S) -> Result<T, human_errors::Error>
+    where
+        TrueResolver: Resolver<S, T>,
+        MockResolver: Resolver<S, T>,
+    {
+        let result = self.resolver.resolve_with(source);
+        self.record_resolve_event::<T>(result.is_ok(), "one");
+        result
+    }
+
+    /// The [`ResolveMany`] counterpart to [`Core::resolve_with_events`].
+    #[cfg(not(test))]
+    pub(crate) fn resolve_many_with_events<S, T>(
+        &self,
+        source: S,
+    ) -> Result<Vec<T>, human_errors::Error>
+    where
+        TrueResolver: ResolveMany<S, T>,
+    {
+        let result = self.resolver.resolve_many_with(source);
+        self.record_resolve_event::<T>(result.is_ok(), "many");
+        result
+    }
+
+    #[cfg(test)]
+    pub(crate) fn resolve_many_with_events<S, T>(
+        &self,
+        source: S,
+    ) -> Result<Vec<T>, human_errors::Error>
+    where
+        TrueResolver: ResolveMany<S, T>,
+        MockResolver: ResolveMany<S, T>,
+    {
+        let result = self.resolver.resolve_many_with(source);
+        self.record_resolve_event::<T>(result.is_ok(), "many");
+        result
+    }
+
+    /// Records a telemetry event for a resolution which has just been performed.
+    /// Only the kind of entity being resolved and the outcome are reported — never
+    /// the source it was resolved from or the entity it resolved to.
+    pub(crate) fn record_resolve_event<T>(&self, success: bool, scope: &'static str) {
+        self.analytics().record_event(
+            format!("resolve::{}", entity_name::<T>()),
+            [
+                (
+                    "status",
+                    if success {
+                        "succeeded".to_string()
+                    } else {
+                        "failed".to_string()
+                    },
+                ),
+                ("scope", scope.to_string()),
+            ],
+        );
+    }
+}
+
+/// The short, lowercased name of the entity type being resolved (for example
+/// `repo`), derived from the Rust type name — hard-coded by construction, and
+/// therefore safe to report.
+fn entity_name<T>() -> String {
+    std::any::type_name::<T>()
+        .rsplit("::")
+        .next()
+        .unwrap_or("unknown")
+        .to_lowercase()
 }
 
 /// The resolver implementation backing a [`super::Core`]: the production

--- a/src/engine/resolve/repo.rs
+++ b/src/engine/resolve/repo.rs
@@ -11,7 +11,7 @@ use tracing_batteries::prelude::*;
 /// Resolves the repository containing the current working directory.
 impl Resolver<(), Repo> for Core {
     fn resolve(&self, source: ()) -> Result<Repo, human_errors::Error> {
-        self.resolver.resolve_with(source)
+        self.resolve_with_events(source)
     }
 }
 
@@ -19,7 +19,7 @@ impl Resolver<(), Repo> for Core {
 /// taking aliases and the configured default service into account.
 impl Resolver<&Identifier, Repo> for Core {
     fn resolve(&self, source: &Identifier) -> Result<Repo, human_errors::Error> {
-        self.resolver.resolve_with(source)
+        self.resolve_with_events(source)
     }
 }
 
@@ -35,14 +35,14 @@ impl Resolver<&str, Repo> for Core {
 /// Enumerates every repository within the development directory.
 impl ResolveMany<(), Repo> for Core {
     fn resolve_many(&self, source: ()) -> Result<Vec<Repo>, human_errors::Error> {
-        self.resolver.resolve_many_with(source)
+        self.resolve_many_with_events(source)
     }
 }
 
 /// Enumerates the repositories belonging to a specific service.
 impl ResolveMany<&Service, Repo> for Core {
     fn resolve_many(&self, source: &Service) -> Result<Vec<Repo>, human_errors::Error> {
-        self.resolver.resolve_many_with(source)
+        self.resolve_many_with_events(source)
     }
 }
 

--- a/src/engine/resolve/scratchpad.rs
+++ b/src/engine/resolve/scratchpad.rs
@@ -8,7 +8,7 @@ use tracing_batteries::prelude::*;
 /// Resolves the current week's scratchpad.
 impl Resolver<(), Scratchpad> for Core {
     fn resolve(&self, source: ()) -> Result<Scratchpad, human_errors::Error> {
-        self.resolver.resolve_with(source)
+        self.resolve_with_events(source)
     }
 }
 
@@ -16,14 +16,14 @@ impl Resolver<(), Scratchpad> for Core {
 /// (e.g. `^1` is last week's scratchpad).
 impl Resolver<&str, Scratchpad> for Core {
     fn resolve(&self, source: &str) -> Result<Scratchpad, human_errors::Error> {
-        self.resolver.resolve_with(source)
+        self.resolve_with_events(source)
     }
 }
 
 /// Enumerates the scratchpads which currently exist on disk.
 impl ResolveMany<(), Scratchpad> for Core {
     fn resolve_many(&self, source: ()) -> Result<Vec<Scratchpad>, human_errors::Error> {
-        self.resolver.resolve_many_with(source)
+        self.resolve_many_with_events(source)
     }
 }
 

--- a/src/engine/resolve/temp.rs
+++ b/src/engine/resolve/temp.rs
@@ -7,7 +7,7 @@ use tracing_batteries::prelude::*;
 /// ([`TempMode::Retain`]) when the target is dropped.
 impl Resolver<TempMode, TempTarget> for Core {
     fn resolve(&self, source: TempMode) -> Result<TempTarget, human_errors::Error> {
-        self.resolver.resolve_with(source)
+        self.resolve_with_events(source)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ mod update;
 mod test;
 
 #[cfg(feature = "telemetry")]
-type TelemetrySession = Session;
+type TelemetrySession = Arc<Session>;
 #[cfg(not(feature = "telemetry"))]
 type TelemetrySession = ();
 
@@ -51,8 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
         match host(app, &session).await {
             Ok(status) => {
-                #[cfg(feature = "telemetry")]
-                session.shutdown();
+                telemetry::shutdown(session);
                 status
             }
             Err(err) => {
@@ -61,8 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     session.record_error(&err);
                 }
 
-                #[cfg(feature = "telemetry")]
-                session.shutdown();
+                telemetry::shutdown(session);
                 1
             }
         }
@@ -179,7 +177,17 @@ async fn host(app: clap::Command, session: &TelemetrySession) -> Result<i32, hum
     #[cfg(not(feature = "telemetry"))]
     let telemetry_enabled = Arc::new(AtomicBool::new(false));
 
-    match run(matches, telemetry_enabled.clone()).await {
+    #[cfg(feature = "telemetry")]
+    let analytics = engine::Analytics::new(session.clone());
+    #[cfg(not(feature = "telemetry"))]
+    let analytics = engine::Analytics::disabled();
+
+    // The event is named after the command so that a session trace reads
+    // naturally; the name is one of the hard-coded subcommands (clap rejects
+    // anything else before we get here) or `help` when none was given.
+    let command_event = format!("commands::{}", matches.subcommand_name().unwrap_or("help"));
+
+    match run(matches, telemetry_enabled.clone(), analytics.clone()).await {
         Ok(-2) => {
             app.clone().print_help().unwrap_or_default();
 
@@ -187,12 +195,29 @@ async fn host(app: clap::Command, session: &TelemetrySession) -> Result<i32, hum
                 .record("otel.status_code", 2_u32)
                 .record("exit_code", 2_u32);
 
+            analytics.record_event(
+                command_event.clone(),
+                [
+                    ("status", "succeeded".to_string()),
+                    ("exit_code", 2.to_string()),
+                ],
+            );
+
             warn!("Exiting with status code {}", 2);
             Ok(2)
         }
         Ok(status) => {
             info!("Exiting with status code {}", status);
             Span::current().record("exit_code", status);
+
+            analytics.record_event(
+                command_event.clone(),
+                [
+                    ("status", "succeeded".to_string()),
+                    ("exit_code", status.to_string()),
+                ],
+            );
+
             Ok(status)
         }
         Err(error) => {
@@ -202,6 +227,21 @@ async fn host(app: clap::Command, session: &TelemetrySession) -> Result<i32, hum
             Span::current()
                 .record("otel.status_code", 2_u32)
                 .record("exit_code", 1_u32);
+
+            analytics.record_event(
+                command_event.clone(),
+                [
+                    ("status", "failed".to_string()),
+                    (
+                        "error_kind",
+                        if error.is(human_errors::Kind::System) {
+                            "system".to_string()
+                        } else {
+                            "user".to_string()
+                        },
+                    ),
+                ],
+            );
 
             if error.is(human_errors::Kind::System) {
                 Span::current().record("exception", display(&error));
@@ -221,10 +261,11 @@ async fn host(app: clap::Command, session: &TelemetrySession) -> Result<i32, hum
     }
 }
 
-#[tracing::instrument(err, skip(matches), fields(command=matches.subcommand_name().unwrap_or("")))]
+#[tracing::instrument(err, skip(matches, analytics), fields(command=matches.subcommand_name().unwrap_or("")))]
 async fn run(
     matches: clap::ArgMatches,
     telemetry_enabled: Arc<AtomicBool>,
+    analytics: engine::Analytics,
 ) -> Result<i32, human_errors::Error> {
     let core_builder = engine::Core::builder();
 
@@ -241,7 +282,7 @@ async fn run(
         core_builder.with_default_config()
     };
 
-    let core = core_builder.build();
+    let core = core_builder.with_analytics(analytics).build();
 
     // If telemetry is enabled in the config file, then turn it on here.
     if !core.config().get_features().has(features::TELEMETRY) {

--- a/src/tasks/create_remote.rs
+++ b/src/tasks/create_remote.rs
@@ -13,6 +13,10 @@ impl Default for CreateRemote {
 
 #[async_trait::async_trait]
 impl Task for CreateRemote {
+    fn name(&self) -> &'static str {
+        "create-remote"
+    }
+
     #[cfg(feature = "auth")]
     #[tracing::instrument(name = "task:create_remote(repo)", err, skip(self, core))]
     async fn apply_repo(&self, core: &Core, repo: &engine::Repo) -> Result<(), engine::Error> {

--- a/src/tasks/ensure_no_remote.rs
+++ b/src/tasks/ensure_no_remote.rs
@@ -13,6 +13,10 @@ impl Default for EnsureNoRemote {
 
 #[async_trait::async_trait]
 impl Task for EnsureNoRemote {
+    fn name(&self) -> &'static str {
+        "ensure-no-remote"
+    }
+
     #[cfg(feature = "auth")]
     #[tracing::instrument(name = "task:ensure_no_remote(repo)", err, skip(self, core))]
     async fn apply_repo(&self, core: &Core, repo: &engine::Repo) -> Result<(), engine::Error> {

--- a/src/tasks/fork_remote.rs
+++ b/src/tasks/fork_remote.rs
@@ -9,6 +9,10 @@ pub struct ForkRemote {
 
 #[async_trait::async_trait]
 impl Task for ForkRemote {
+    fn name(&self) -> &'static str {
+        "fork-remote"
+    }
+
     #[cfg(feature = "auth")]
     #[tracing::instrument(name = "task:fork_repository(repo)", err, skip(self, core))]
     async fn apply_repo(&self, core: &Core, repo: &Repo) -> Result<(), engine::Error> {

--- a/src/tasks/git_add.rs
+++ b/src/tasks/git_add.rs
@@ -9,6 +9,10 @@ pub struct GitAdd<'a> {
 
 #[async_trait::async_trait]
 impl Task for GitAdd<'_> {
+    fn name(&self) -> &'static str {
+        "git-add"
+    }
+
     #[tracing::instrument(name = "task:git_add(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &engine::Repo) -> Result<(), engine::Error> {
         git::git_add(&repo.get_path(), &self.paths).await

--- a/src/tasks/git_branch_delete.rs
+++ b/src/tasks/git_branch_delete.rs
@@ -8,6 +8,10 @@ pub struct GitBranchDelete {
 
 #[async_trait::async_trait]
 impl Task for GitBranchDelete {
+    fn name(&self) -> &'static str {
+        "git-branch-delete"
+    }
+
     #[tracing::instrument(name = "task:git_branch_delete(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &engine::Repo) -> Result<(), engine::Error> {
         git::git_branch_delete(&repo.get_path(), &self.branch).await

--- a/src/tasks/git_checkout.rs
+++ b/src/tasks/git_checkout.rs
@@ -8,6 +8,10 @@ pub struct GitCheckout<'a> {
 
 #[async_trait::async_trait]
 impl Task for GitCheckout<'_> {
+    fn name(&self) -> &'static str {
+        "git-checkout"
+    }
+
     #[tracing::instrument(name = "task:git_checkout(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &engine::Repo) -> Result<(), engine::Error> {
         git::git_checkout(&repo.get_path(), self.branch).await

--- a/src/tasks/git_clone.rs
+++ b/src/tasks/git_clone.rs
@@ -9,6 +9,10 @@ pub struct GitClone {
 
 #[async_trait::async_trait]
 impl Task for GitClone {
+    fn name(&self) -> &'static str {
+        "git-clone"
+    }
+
     #[tracing::instrument(name = "task:git_clone(repo)", err, skip(self, core))]
     async fn apply_repo(&self, core: &Core, repo: &engine::Repo) -> Result<(), engine::Error> {
         if repo.exists() {

--- a/src/tasks/git_commit.rs
+++ b/src/tasks/git_commit.rs
@@ -10,6 +10,10 @@ pub struct GitCommit<'a> {
 
 #[async_trait::async_trait]
 impl Task for GitCommit<'_> {
+    fn name(&self) -> &'static str {
+        "git-commit"
+    }
+
     #[tracing::instrument(name = "task:git_commit(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &engine::Repo) -> Result<(), engine::Error> {
         git::git_commit(&repo.get_path(), self.message, &self.paths).await

--- a/src/tasks/git_init.rs
+++ b/src/tasks/git_init.rs
@@ -6,6 +6,10 @@ pub struct GitInit {}
 
 #[async_trait::async_trait]
 impl Task for GitInit {
+    fn name(&self) -> &'static str {
+        "git-init"
+    }
+
     #[tracing::instrument(name = "task:git_init(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &engine::Repo) -> Result<(), engine::Error> {
         git::git_init(&repo.get_path()).await?;

--- a/src/tasks/git_remote.rs
+++ b/src/tasks/git_remote.rs
@@ -14,6 +14,10 @@ impl Default for GitRemote<'static> {
 
 #[async_trait::async_trait]
 impl Task for GitRemote<'_> {
+    fn name(&self) -> &'static str {
+        "git-remote"
+    }
+
     #[tracing::instrument(name = "task:git_remote(repo)", err, skip(self, core))]
     async fn apply_repo(&self, core: &Core, repo: &engine::Repo) -> Result<(), engine::Error> {
         let service = core.config().get_service(&repo.service)?;
@@ -39,6 +43,10 @@ pub struct GitAddRemote {
 
 #[async_trait::async_trait]
 impl Task for GitAddRemote {
+    fn name(&self) -> &'static str {
+        "git-add-remote"
+    }
+
     #[tracing::instrument(name = "task:git_remote(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &engine::Repo) -> Result<(), engine::Error> {
         if git::git_remote_list(&repo.get_path())

--- a/src/tasks/git_switch.rs
+++ b/src/tasks/git_switch.rs
@@ -9,6 +9,10 @@ pub struct GitSwitch {
 
 #[async_trait::async_trait]
 impl Task for GitSwitch {
+    fn name(&self) -> &'static str {
+        "git-switch"
+    }
+
     #[tracing::instrument(name = "task:git_switch(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &engine::Repo) -> Result<(), engine::Error> {
         let mut create = self.create_if_missing;

--- a/src/tasks/git_worktree.rs
+++ b/src/tasks/git_worktree.rs
@@ -13,6 +13,10 @@ pub struct GitWorktree {
 
 #[async_trait::async_trait]
 impl Task for GitWorktree {
+    fn name(&self) -> &'static str {
+        "git-worktree"
+    }
+
     #[tracing::instrument(name = "task:git_worktree(repo)", err, skip(self, core))]
     async fn apply_repo(&self, core: &Core, repo: &engine::Repo) -> Result<(), engine::Error> {
         if self.path.exists() {

--- a/src/tasks/git_worktree_remove.rs
+++ b/src/tasks/git_worktree_remove.rs
@@ -9,6 +9,10 @@ pub struct GitWorktreeRemove {
 
 #[async_trait::async_trait]
 impl Task for GitWorktreeRemove {
+    fn name(&self) -> &'static str {
+        "git-worktree-remove"
+    }
+
     #[tracing::instrument(name = "task:git_worktree_remove(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &engine::Repo) -> Result<(), engine::Error> {
         git::git_worktree_remove(&repo.get_path(), &self.path).await

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -60,6 +60,13 @@ pub use write_file::WriteFile;
 
 #[async_trait]
 pub trait Task {
+    /// A short, hard-coded name identifying this kind of task in telemetry events.
+    ///
+    /// The name must be a compile-time literal describing the operation only (for
+    /// example `git-clone`) so that it can never leak information about the entity
+    /// the task is applied to — never derive it from the task's arguments.
+    fn name(&self) -> &'static str;
+
     async fn apply_repo(&self, _core: &Core, _repo: &engine::Repo) -> Result<(), engine::Error> {
         Ok(())
     }
@@ -93,6 +100,10 @@ impl Default for TestTask {
 #[cfg(test)]
 #[async_trait]
 impl Task for TestTask {
+    fn name(&self) -> &'static str {
+        "test"
+    }
+
     async fn apply_repo(&self, _core: &Core, repo: &engine::Repo) -> Result<(), engine::Error> {
         let mut r = self.ran_repo.lock().await;
 

--- a/src/tasks/move_directory.rs
+++ b/src/tasks/move_directory.rs
@@ -10,6 +10,10 @@ pub struct MoveDirectory {
 
 #[async_trait::async_trait]
 impl Task for MoveDirectory {
+    fn name(&self) -> &'static str {
+        "move-directory"
+    }
+
     #[tracing::instrument(name = "task:move_directory(repo)", err, skip(self, _core))]
     async fn apply_repo(
         &self,

--- a/src/tasks/move_remote.rs
+++ b/src/tasks/move_remote.rs
@@ -9,6 +9,10 @@ pub struct MoveRemote {
 
 #[async_trait::async_trait]
 impl Task for MoveRemote {
+    fn name(&self) -> &'static str {
+        "move-remote"
+    }
+
     #[cfg(feature = "auth")]
     #[tracing::instrument(name = "task:move_remote(repo)", err, skip(self, core))]
     async fn apply_repo(&self, core: &Core, repo: &Repo) -> Result<(), engine::Error> {

--- a/src/tasks/new_folder.rs
+++ b/src/tasks/new_folder.rs
@@ -6,6 +6,10 @@ pub struct NewFolder {}
 
 #[async_trait::async_trait]
 impl Task for NewFolder {
+    fn name(&self) -> &'static str {
+        "new-folder"
+    }
+
     #[tracing::instrument(name = "task:new_folder(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &engine::Repo) -> Result<(), engine::Error> {
         let path = repo.get_path();

--- a/src/tasks/sequence.rs
+++ b/src/tasks/sequence.rs
@@ -14,10 +14,16 @@ impl Sequence {
 
 #[async_trait]
 impl Task for Sequence {
+    fn name(&self) -> &'static str {
+        "sequence"
+    }
+
     #[tracing::instrument(name = "task:sequence(repo)", err, skip(self, core))]
     async fn apply_repo(&self, core: &Core, repo: &engine::Repo) -> Result<(), engine::Error> {
         for task in self.tasks.iter() {
-            task.apply_repo(core, repo).await?;
+            let result = task.apply_repo(core, repo).await;
+            record_task_event(core, task.as_ref(), "repo", &result);
+            result?;
         }
 
         Ok(())
@@ -30,11 +36,43 @@ impl Task for Sequence {
         scratch: &engine::Scratchpad,
     ) -> Result<(), engine::Error> {
         for task in self.tasks.iter() {
-            task.apply_scratchpad(core, scratch).await?;
+            let result = task.apply_scratchpad(core, scratch).await;
+            record_task_event(core, task.as_ref(), "scratchpad", &result);
+            result?;
         }
 
         Ok(())
     }
+}
+
+/// Records a telemetry event for a task which has just been applied. Only the
+/// task's hard-coded [`Task::name`] and the kind of target it was applied to are
+/// reported — never anything about the target itself.
+fn record_task_event(
+    core: &Core,
+    task: &(dyn Task + Send + Sync),
+    target: &'static str,
+    result: &Result<(), engine::Error>,
+) {
+    // Nested sequences report their child tasks themselves.
+    if task.name() == "sequence" {
+        return;
+    }
+
+    core.analytics().record_event(
+        format!("tasks::{}", task.name()),
+        [
+            (
+                "status",
+                if result.is_ok() {
+                    "succeeded".to_string()
+                } else {
+                    "failed".to_string()
+                },
+            ),
+            ("target", target.to_string()),
+        ],
+    );
 }
 
 #[cfg(test)]

--- a/src/tasks/write_file.rs
+++ b/src/tasks/write_file.rs
@@ -11,6 +11,10 @@ pub struct WriteFile<'a> {
 
 #[async_trait::async_trait]
 impl Task for WriteFile<'_> {
+    fn name(&self) -> &'static str {
+        "write-file"
+    }
+
     #[tracing::instrument(name = "task:write_file(repo)", err, skip(self, _core))]
     async fn apply_repo(&self, _core: &Core, repo: &engine::Repo) -> Result<(), engine::Error> {
         let path = repo.get_path().join(&self.path);

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,8 +1,19 @@
 use std::sync::Arc;
 use tracing_batteries::prelude::*;
 
+/// Initializes the telemetry session for this run of Git-Tool.
+///
+/// The session is returned behind an [`Arc`] so that a handle to it can be shared
+/// with the [`crate::engine::Core`] (via [`crate::engine::Analytics`]), allowing usage
+/// events to be recorded from anywhere in the application. The `main` function keeps
+/// the original reference and hands it back to [`shutdown`] once the run completes.
 #[cfg(feature = "telemetry")]
-pub fn setup() -> tracing_batteries::Session {
+pub fn setup() -> Arc<tracing_batteries::Session> {
+    Arc::new(session())
+}
+
+#[cfg(feature = "telemetry")]
+fn session() -> tracing_batteries::Session {
     tracing_batteries::Session::new("git-tool", version!())
         .with_battery(tracing_batteries::Sentry::new((
             "https://0787127414b24323be5a3d34767cb9b8@o219072.ingest.sentry.io/1486938",
@@ -42,3 +53,23 @@ pub fn setup() -> tracing_batteries::Session {
 pub fn setup() -> () {
     ()
 }
+
+/// Shuts down the telemetry session, flushing any buffered telemetry before the
+/// process exits.
+///
+/// By this point the [`crate::engine::Core`] (and with it every shared handle to the
+/// session) has been dropped, so reclaiming exclusive ownership from the [`Arc`] is
+/// expected to succeed; if some handle does still exist we skip the final flush
+/// rather than blocking or crashing on our way out.
+#[cfg(feature = "telemetry")]
+pub fn shutdown(session: Arc<tracing_batteries::Session>) {
+    match Arc::try_unwrap(session) {
+        Ok(session) => session.shutdown(),
+        Err(_) => {
+            warn!("The telemetry session is still shared elsewhere, skipping the final flush.")
+        }
+    }
+}
+
+#[cfg(not(feature = "telemetry"))]
+pub fn shutdown(_session: ()) {}


### PR DESCRIPTION
## Summary

Exposes the tracing-batteries telemetry session through a new `engine::Core::analytics()` handle and records usage events for Git-Tool's key operations, building on the upstream change that made `Session` `Send + Sync + 'static`.

### The `Analytics` handle

- `engine::Analytics` wraps an `Option<Arc<Session>>`: cloneable, thread-safe, and a no-op when no session is attached (tests, `--no-default-features` builds). Event delivery also remains gated by the session's enabled flag, which honours the user's `telemetry` feature flag.
- `main` wraps the session in an `Arc`, hands a handle into the `CoreBuilder`, and reclaims exclusive ownership at exit for the final flush (`telemetry::shutdown`).

### Events

Events are named after the operation so session traces group naturally and read intuitively, with the outcome in a uniform `status` (`succeeded`/`failed`) property:

| Event | Properties | Emitted from |
|---|---|---|
| `commands::{name}` | `status`, `exit_code` / `error_kind` | `host()` in `main.rs` |
| `tasks::{name}` | `status`, `target` | `Sequence` (all task call sites now route through it), via new `Task::name()` |
| `resolve::{entity}` | `status`, `scope` | tracked resolver forwarding on `Core` |
| `apps::launched` / `apps::exited` | `status`, `exit_code` | `InstrumentedLauncher` decorator |
| `http::request` | `status`, `method`, `code` | `InstrumentedHttpClient` decorator |
| `update::started` / `update::{phase}` | `status`; `to_version`, `prerelease` | the `update` command |

### Privacy

Every event-name segment comes from a hard-coded set: clap-validated subcommand names, `Task::name()` literals (documented as compile-time constants), Rust type names, and update-rs phase names (an undeserializable `--state` reports as `update::invalid`, never echoing the input). Property keys are forced to `&'static str` by the `record_event` signature, and values are limited to exit codes, counts, booleans, and public release versions — no hostnames, repository/application/branch names, or paths.

## Testing

- Full suite passes (289 tests; the gitignore network tests are the known parallel-run flake and pass isolated).
- Verified end-to-end by pointing the Analytics battery at a local listener and driving the built binary; captured events for `gt list`, `gt scratch` (including `tasks::new-folder`, `apps::launched`/`apps::exited`), and a garbage `gt update --state` probe (sanitized to `update::invalid`), confirming no user-identifying data on the wire. The recipe is preserved in `.claude/skills/verify/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)