### PR TITLE
fix: Swallow broken pipes on stdout/stderr

### DIFF
--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -40,7 +40,78 @@ impl ConsoleProvider for DefaultConsoleProvider {
     }
 
     fn output(&self) -> Box<dyn Write + Send> {
-        Box::new(stdout())
+        Box::new(PipeSafeWriter::new(stdout()))
+    }
+}
+
+/// A [`Write`] adapter which tolerates the output stream being torn down (the
+/// terminal being closed, or a downstream reader in a pipe exiting) rather than
+/// surfacing the resulting IO error.
+///
+/// Command output flows through here from every subcommand, so a broken pipe
+/// would otherwise bubble up as a `human_errors::Error` (printed to the user
+/// and, for system errors, reported to telemetry) or, in the case of the raw
+/// print macros, panic outright. When the consumer of our output has gone away
+/// there is nothing useful to do with the bytes and nowhere to report the
+/// failure, so we drop the remaining output silently. This mirrors the way
+/// traditional Unix tools are terminated by `SIGPIPE` without complaint, and
+/// keeps `git-tool ... | head` (or closing the terminal mid-command) from
+/// producing spurious errors.
+///
+/// Only disconnection-style errors are swallowed; genuine failures (for example
+/// a full disk when output is redirected to a file) continue to propagate as
+/// before.
+struct PipeSafeWriter<W> {
+    inner: W,
+    disconnected: bool,
+}
+
+impl<W: Write> PipeSafeWriter<W> {
+    fn new(inner: W) -> Self {
+        Self {
+            inner,
+            disconnected: false,
+        }
+    }
+}
+
+/// Returns `true` when an IO error indicates the consumer of our output has gone
+/// away, as opposed to a recoverable or reportable failure.
+fn is_disconnection(err: &std::io::Error) -> bool {
+    // `BrokenPipe` covers a downstream reader exiting on every platform (and is
+    // what Windows maps its broken-pipe error codes to). The raw `EIO` (os error
+    // 5) check covers a terminal/pty being torn down on Unix, which surfaces as
+    // an uncategorised IO error rather than `BrokenPipe`.
+    err.kind() == std::io::ErrorKind::BrokenPipe || err.raw_os_error() == Some(5)
+}
+
+impl<W: Write> Write for PipeSafeWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if self.disconnected {
+            return Ok(buf.len());
+        }
+
+        match self.inner.write(buf) {
+            Err(e) if is_disconnection(&e) => {
+                self.disconnected = true;
+                Ok(buf.len())
+            }
+            other => other,
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        if self.disconnected {
+            return Ok(());
+        }
+
+        match self.inner.flush() {
+            Err(e) if is_disconnection(&e) => {
+                self.disconnected = true;
+                Ok(())
+            }
+            other => other,
+        }
     }
 }
 
@@ -109,5 +180,83 @@ impl From<String> for MockConsoleProvider {
 impl Display for MockConsoleProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", &self.output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `Write` whose every call fails with a configurable error, used to
+    /// exercise `PipeSafeWriter`'s error handling.
+    struct FailingWriter {
+        error: fn() -> std::io::Error,
+        writes: usize,
+    }
+
+    impl FailingWriter {
+        fn new(error: fn() -> std::io::Error) -> Self {
+            Self { error, writes: 0 }
+        }
+    }
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            self.writes += 1;
+            Err((self.error)())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Err((self.error)())
+        }
+    }
+
+    #[test]
+    fn pipe_safe_writer_passes_through_successful_writes() {
+        let mut buffer: Vec<u8> = Vec::new();
+        let mut writer = PipeSafeWriter::new(&mut buffer);
+
+        assert_eq!(writer.write(b"hello").unwrap(), 5);
+        writer.flush().unwrap();
+        assert!(!writer.disconnected);
+        assert_eq!(buffer, b"hello");
+    }
+
+    #[test]
+    fn pipe_safe_writer_swallows_broken_pipe() {
+        let mut writer =
+            PipeSafeWriter::new(FailingWriter::new(|| std::io::ErrorKind::BrokenPipe.into()));
+
+        // The broken pipe is reported as a successful write of the whole buffer
+        // rather than an error, and the writer latches into the disconnected
+        // state so later writes are dropped without touching the inner writer.
+        assert_eq!(writer.write(b"hello").unwrap(), 5);
+        assert!(writer.disconnected);
+        assert_eq!(writer.write(b"world").unwrap(), 5);
+        assert_eq!(writer.inner.writes, 1);
+        writer.flush().unwrap();
+    }
+
+    #[test]
+    fn pipe_safe_writer_swallows_eio() {
+        // `EIO` (os error 5) is what a torn-down terminal produces on Unix.
+        let mut writer =
+            PipeSafeWriter::new(FailingWriter::new(|| std::io::Error::from_raw_os_error(5)));
+
+        assert_eq!(writer.write(b"hello").unwrap(), 5);
+        assert!(writer.disconnected);
+    }
+
+    #[test]
+    fn pipe_safe_writer_propagates_other_errors() {
+        // A genuine failure (e.g. a full disk when redirected to a file) must
+        // still surface rather than being silently dropped.
+        let mut writer = PipeSafeWriter::new(FailingWriter::new(|| {
+            std::io::ErrorKind::PermissionDenied.into()
+        }));
+
+        let err = writer.write(b"hello").unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(!writer.disconnected);
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -19,3 +19,19 @@ macro_rules! version {
         format!("{}0.0.0-dev", $prefix)
     };
 }
+
+/// Like [`eprintln!`], but never panics when the standard error stream has been
+/// torn down (for example when the terminal is closed while a command is still
+/// running).
+///
+/// The built-in `eprintln!`/`println!` macros unwrap the underlying write and
+/// panic on failure (`failed printing to stderr: ...`). When the terminal or a
+/// downstream pipe goes away mid-write that turns an unremarkable shutdown into
+/// a crash which our panic hook then reports as an exception. There is nowhere
+/// left to surface the message in that situation, so we simply drop it.
+macro_rules! safe_eprintln {
+    ($($arg:tt)*) => {{
+        use std::io::Write;
+        let _ = writeln!(std::io::stderr(), $($arg)*);
+    }};
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,7 +132,7 @@ async fn host(
 
             #[cfg(feature = "telemetry")]
             if session.enable().load(std::sync::atomic::Ordering::Relaxed) {
-                eprintln!(
+                safe_eprintln!(
                     "Trace ID: {:032x}",
                     Span::current().context().span().span_context().trace_id()
                 );
@@ -220,7 +220,7 @@ async fn host(
             Ok(status)
         }
         Err(error) => {
-            eprintln!("{}", human_errors::pretty(&error));
+            safe_eprintln!("{}", human_errors::pretty(&error));
 
             error!("Exiting with status code {}", 1);
             Span::current()
@@ -258,7 +258,7 @@ async fn host(
             }
 
             if telemetry_enabled.load(std::sync::atomic::Ordering::Relaxed) {
-                eprintln!(
+                safe_eprintln!(
                     "Trace ID: {:032x}",
                     Span::current().context().span().span_context().trace_id()
                 );
@@ -301,7 +301,7 @@ async fn run(
     if matches.get_flag("trace") {
         debug!("Tracing enabled by command line flag.");
         telemetry_enabled.store(true, std::sync::atomic::Ordering::Relaxed);
-        eprintln!(
+        safe_eprintln!(
             "Tracing enabled, your trace ID is: {:032x}",
             Span::current().context().span().span_context().trace_id()
         );


### PR DESCRIPTION
## Problem

We've been receiving exception reports for panics like:

```
failed printing to stdout: Input/output error (os error 5)
panicked at library/std/src/io/stdio.rs:1165:9
```

These originate from the `println!`/`eprintln!` print macros, which unwrap the underlying write internally and panic on failure. When the terminal is closed (or a downstream pipe reader exits) mid-command, the write returns `BrokenPipe`/`EIO`, the macro panics, and the `tracing-batteries` analytics panic hook then files it as an exception report. An unremarkable shutdown turns into crash noise.

## Changes

- **`PipeSafeWriter` (`src/console/mod.rs`)** — a `Write` adapter wrapping the `stdout()` returned by `DefaultConsoleProvider::output()`, the single choke point that essentially all command output flows through. It swallows disconnection errors (`BrokenPipe` on every platform, plus raw `EIO` / os error 5 for a torn-down Unix terminal) and latches into a sink after the first one, so output degrades silently when the consumer goes away — mirroring how traditional Unix tools are terminated by `SIGPIPE` without complaint. Genuine failures (e.g. a full disk when output is redirected to a file) still propagate as before.
- **`safe_eprintln!` (`src/macros.rs`)** — a drop-in for `eprintln!` that writes to stderr via `writeln!` and ignores the result, so it never panics when stderr has been torn down. Kept on stderr (rather than routing through `tracing::error!`) because git-tool has no local tracing fmt layer, so error output must still reach the user's terminal.
- **`src/main.rs`** — replaced all 4 runtime `eprintln!` calls (trace ID on clap error, the primary error sink printing `human_errors::pretty`, trace ID after a command error, and the `--trace` enablement message) with `safe_eprintln!`.

## Result

Closing the terminal mid-command, or `git-tool ... | head`, no longer panics or emits spurious error output / telemetry — the process degrades silently on disconnection while still surfacing real IO failures.

## Testing

- `cargo build`, `cargo clippy --all-targets` (no new warnings)
- Added 4 unit tests for `PipeSafeWriter` covering pass-through, `BrokenPipe` swallowing + latching, `EIO` swallowing, and propagation of genuine errors
- Existing `console::` tests pass
