### PR TITLE
chore: Migrate fuzzing from cargo-fuzz to cargo-afl

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -33,13 +33,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install nightly Rust
-        uses: dtolnay/rust-toolchain@nightly
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libdbus-1-3 libdbus-1-dev
+          sudo apt-get install -y libdbus-1-3 libdbus-1-dev clang llvm
 
       - name: Install protoc
         uses: SierraSoftworks/setup-protoc@v3.0.1
@@ -54,10 +54,17 @@ jobs:
             fuzz -> fuzz/target
           key: fuzz-${{ matrix.target }}
 
-      - name: Install cargo-fuzz
+      - name: Install cargo-afl
         uses: taiki-e/install-action@v2.84.0
         with:
-          tool: cargo-fuzz
+          tool: cargo-afl
+
+      - name: Build AFL toolchain
+        run: cargo afl config --build --plugins
+
+      - name: Configure system for AFL++
+        run: |
+          sudo cargo afl system-config
 
       - name: Run fuzz target
         id: fuzz
@@ -77,7 +84,7 @@ jobs:
           name: fuzz-failure-${{ matrix.target }}-${{ github.run_id }}
           path: |
             fuzz-${{ matrix.target }}.log
-            fuzz/artifacts/${{ matrix.target }}
+            fuzz/corpus-output/${{ matrix.target }}/default/crashes
           if-no-files-found: warn
           retention-days: 30
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 #Added by cargo
 
 /target
-/fuzz/artifacts
 /fuzz/corpus-output
 /fuzz/target
 *.profraw

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -4,14 +4,11 @@ version = "0.0.0"
 publish = false
 edition = "2024"
 
-[package.metadata]
-cargo-fuzz = true
-
 [dependencies]
+afl = "0.15"
 clap = "4.6.1"
 git-tool = { path = ".." }
 gotmpl = "0.6.1"
-libfuzzer-sys = "0.4"
 serde_yaml = "0.9"
 tempfile = "3.27"
 tokio = { version = "1.52", features = ["rt-multi-thread"] }

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,6 +1,7 @@
 # Fuzzing
 
-Run the template fuzzer for 60 seconds:
+Fuzzing uses [`cargo-afl`](https://rust-fuzz.github.io/book/afl/tutorial.html)
+(AFL++). Run the template fuzzer for 60 seconds:
 
 ```console
 ./scripts/fuzz
@@ -12,23 +13,38 @@ Choose another target and duration:
 ./scripts/fuzz commands 300
 ```
 
-Arguments after the duration are passed to libFuzzer. For example, this runs
-the checked-in template corpus once:
+Arguments after the duration are passed to `afl-fuzz`. For example, this limits
+each execution to a 10 second timeout:
 
 ```console
-./scripts/fuzz templates 0 -runs=1
+./scripts/fuzz templates 60 -t 10000
 ```
 
-The script requires the nightly Rust toolchain and `cargo-fuzz`:
+The script requires a stable Rust toolchain and `cargo-afl`:
 
 ```console
-rustup toolchain install nightly
-cargo install cargo-fuzz
+cargo install cargo-afl
+cargo afl config --build
 ```
 
-Generated corpus entries are written to `fuzz/corpus-output/<target>`. The
-checked-in files under `fuzz/corpus/<target>` are used as read-only seeds.
+`cargo afl config --build` installs the AFL++ tooling that `cargo afl build`
+relies on the first time you fuzz.
 
-Set `FUZZ_SANITIZER` to select a cargo-fuzz sanitizer explicitly. Sanitizers
-default to disabled on Apple Silicon because the instrumented binary currently
-fails to link there; other platforms use cargo-fuzz's default sanitizer.
+The checked-in files under `fuzz/corpus/<target>` are used as read-only seed
+inputs. AFL writes its session state and any discovered crashes to
+`fuzz/corpus-output/<target>` (which is git-ignored). Crashes are stored under
+`fuzz/corpus-output/<target>/default/crashes`.
+
+Reproduce a crash by piping it back into the target binary:
+
+```console
+cargo afl run --release --manifest-path fuzz/Cargo.toml --bin templates \
+    < fuzz/corpus-output/templates/default/crashes/<crash-file>
+```
+
+The script sets `AFL_SKIP_CPUFREQ`, `AFL_NO_AFFINITY` and
+`AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES` so it runs non-interactively in CI and
+on machines where the kernel core pattern or CPU governor cannot be
+reconfigured. It also sets `AFL_BENCH_UNTIL_CRASH` so a run stops as soon as a
+reproducible crash is found. Override any of these by exporting them before
+invoking the script.

--- a/fuzz/fuzz_targets/commands.rs
+++ b/fuzz/fuzz_targets/commands.rs
@@ -1,16 +1,16 @@
-#![no_main]
-
+use afl::fuzz;
 use git_tool::commands;
-use libfuzzer_sys::fuzz_target;
 use std::sync::LazyLock;
 
 mod common;
 
-fuzz_target!(|data: &[u8]| {
-    static APP: LazyLock<clap::Command> = LazyLock::new(commands::app);
+fn main() {
+    fuzz!(|data: &[u8]| {
+        static APP: LazyLock<clap::Command> = LazyLock::new(commands::app);
 
-    let mut arguments = vec!["git-tool".to_string()];
-    arguments.extend(common::fields(data));
+        let mut arguments = vec!["git-tool".to_string()];
+        arguments.extend(common::fields(data));
 
-    let _ = APP.clone().try_get_matches_from(arguments);
-});
+        let _ = APP.clone().try_get_matches_from(arguments);
+    });
+}

--- a/fuzz/fuzz_targets/completion.rs
+++ b/fuzz/fuzz_targets/completion.rs
@@ -1,10 +1,8 @@
-#![no_main]
-
+use afl::fuzz;
 use git_tool::{
     completion,
     engine::{Branch, Core},
 };
-use libfuzzer_sys::fuzz_target;
 use std::sync::OnceLock;
 
 mod common;
@@ -14,34 +12,36 @@ fn core() -> &'static Core {
     CORE.get_or_init(|| Core::builder().with_default_config().build())
 }
 
-fuzz_target!(|data: &[u8]| {
-    let (context_flag, input) = data.split_first().unwrap_or((&0, &[]));
-    let tokens = common::fields(input);
-    let arguments = std::iter::once("completion-fuzz").chain(tokens.iter().map(String::as_str));
-    let matches = clap::Command::new("completion-fuzz")
-        .arg(
-            clap::Arg::new("args")
-                .action(clap::ArgAction::Append)
-                .allow_hyphen_values(true),
-        )
-        .try_get_matches_from(arguments);
+fn main() {
+    fuzz!(|data: &[u8]| {
+        let (context_flag, input) = data.split_first().unwrap_or((&0, &[]));
+        let tokens = common::fields(input);
+        let arguments = std::iter::once("completion-fuzz").chain(tokens.iter().map(String::as_str));
+        let matches = clap::Command::new("completion-fuzz")
+            .arg(
+                clap::Arg::new("args")
+                    .action(clap::ArgAction::Append)
+                    .allow_hyphen_values(true),
+            )
+            .try_get_matches_from(arguments);
 
-    let Ok(matches) = matches else {
-        return;
-    };
+        let Ok(matches) = matches else {
+            return;
+        };
 
-    let context = (*context_flag & 1 != 0)
-        .then(|| "current".parse::<Branch>().expect("a valid context branch"));
+        let context = (*context_flag & 1 != 0)
+            .then(|| "current".parse::<Branch>().expect("a valid context branch"));
 
-    if let Ok(parsed) = completion::parse::<Branch>(core(), context.as_ref(), &matches) {
-        assert!(!parsed.target.as_str().is_empty());
-        for (key, value) in &parsed.env {
-            let original = format!("{key}={value}");
-            assert!(tokens.contains(&original));
+        if let Ok(parsed) = completion::parse::<Branch>(core(), context.as_ref(), &matches) {
+            assert!(!parsed.target.as_str().is_empty());
+            for (key, value) in &parsed.env {
+                let original = format!("{key}={value}");
+                assert!(tokens.contains(&original));
+            }
+
+            parsed
+                .launch_app(core())
+                .expect("successfully parsed arguments to produce a launchable app");
         }
-
-        parsed
-            .launch_app(core())
-            .expect("successfully parsed arguments to produce a launchable app");
-    }
-});
+    });
+}

--- a/fuzz/fuzz_targets/config.rs
+++ b/fuzz/fuzz_targets/config.rs
@@ -1,28 +1,28 @@
-#![no_main]
-
+use afl::fuzz;
 use git_tool::engine::Config;
-use libfuzzer_sys::fuzz_target;
 use std::io::Cursor;
 
 mod common;
 
-fuzz_target!(|data: &[u8]| {
-    let input = common::bounded_bytes(data);
+fn main() {
+    fuzz!(|data: &[u8]| {
+        let input = common::bounded_bytes(data);
 
-    if let Ok(config) = Config::from_reader(Cursor::new(input)) {
-        let canonical = config
-            .to_string()
-            .expect("a parsed configuration to serialize");
-        let reparsed = Config::from_reader(Cursor::new(canonical.as_bytes()))
-            .expect("a serialized configuration to parse");
-        let reserialized = reparsed
-            .to_string()
-            .expect("a reparsed configuration to serialize");
-        let canonical_value: serde_yaml::Value =
-            serde_yaml::from_str(&canonical).expect("a serialized configuration to be valid YAML");
-        let reserialized_value: serde_yaml::Value = serde_yaml::from_str(&reserialized)
-            .expect("a reserialized configuration to be valid YAML");
+        if let Ok(config) = Config::from_reader(Cursor::new(input)) {
+            let canonical = config
+                .to_string()
+                .expect("a parsed configuration to serialize");
+            let reparsed = Config::from_reader(Cursor::new(canonical.as_bytes()))
+                .expect("a serialized configuration to parse");
+            let reserialized = reparsed
+                .to_string()
+                .expect("a reparsed configuration to serialize");
+            let canonical_value: serde_yaml::Value = serde_yaml::from_str(&canonical)
+                .expect("a serialized configuration to be valid YAML");
+            let reserialized_value: serde_yaml::Value = serde_yaml::from_str(&reserialized)
+                .expect("a reserialized configuration to be valid YAML");
 
-        assert_eq!(canonical_value, reserialized_value);
-    }
-});
+            assert_eq!(canonical_value, reserialized_value);
+        }
+    });
+}

--- a/fuzz/fuzz_targets/git_operations.rs
+++ b/fuzz/fuzz_targets/git_operations.rs
@@ -1,37 +1,37 @@
-#![no_main]
-
+use afl::fuzz;
 use git_tool::git;
-use libfuzzer_sys::fuzz_target;
 
 mod common;
 
-fuzz_target!(|data: &[u8]| {
-    common::runtime().block_on(async {
-        let temp = tempfile::tempdir().expect("a temporary repository directory");
-        git::git_init(temp.path())
-            .await
-            .expect("git init to succeed");
-
-        for (opcode, branch) in common::operations(data) {
-            match opcode % 4 {
-                0 => {
-                    let _ = git::git_checkout(temp.path(), &branch).await;
-                }
-                1 => {
-                    let _ = git::git_switch(temp.path(), &branch, true).await;
-                }
-                2 => {
-                    let _ = git::git_switch(temp.path(), &branch, false).await;
-                }
-                _ => {
-                    let _ = git::git_branch_delete(temp.path(), &branch).await;
-                }
-            }
-
-            assert!(temp.path().join(".git").is_dir());
-            git::git_branches(temp.path())
+fn main() {
+    fuzz!(|data: &[u8]| {
+        common::runtime().block_on(async {
+            let temp = tempfile::tempdir().expect("a temporary repository directory");
+            git::git_init(temp.path())
                 .await
-                .expect("the initialized repository to remain queryable");
-        }
+                .expect("git init to succeed");
+
+            for (opcode, branch) in common::operations(data) {
+                match opcode % 4 {
+                    0 => {
+                        let _ = git::git_checkout(temp.path(), &branch).await;
+                    }
+                    1 => {
+                        let _ = git::git_switch(temp.path(), &branch, true).await;
+                    }
+                    2 => {
+                        let _ = git::git_switch(temp.path(), &branch, false).await;
+                    }
+                    _ => {
+                        let _ = git::git_branch_delete(temp.path(), &branch).await;
+                    }
+                }
+
+                assert!(temp.path().join(".git").is_dir());
+                git::git_branches(temp.path())
+                    .await
+                    .expect("the initialized repository to remain queryable");
+            }
+        });
     });
-});
+}

--- a/fuzz/fuzz_targets/identifier.rs
+++ b/fuzz/fuzz_targets/identifier.rs
@@ -1,30 +1,30 @@
-#![no_main]
-
+use afl::fuzz;
 use git_tool::engine::Identifier;
-use libfuzzer_sys::fuzz_target;
 
 mod common;
 
-fuzz_target!(|data: &[u8]| {
-    let mut fields = data.splitn(2, |byte| *byte == 0);
-    let source = common::bounded_text(fields.next().unwrap_or_default());
-    let partial = common::bounded_text(fields.next().unwrap_or_default());
+fn main() {
+    fuzz!(|data: &[u8]| {
+        let mut fields = data.splitn(2, |byte| *byte == 0);
+        let source = common::bounded_text(fields.next().unwrap_or_default());
+        let partial = common::bounded_text(fields.next().unwrap_or_default());
 
-    if let Ok(identifier) = source.parse::<Identifier>() {
-        assert!(!identifier.path.trim().is_empty());
+        if let Ok(identifier) = source.parse::<Identifier>() {
+            assert!(!identifier.path.trim().is_empty());
 
-        let rendered = identifier.to_string();
-        let reparsed = rendered
-            .parse::<Identifier>()
-            .expect("a rendered identifier to remain valid");
-        assert_eq!(reparsed, identifier);
-
-        if let Ok(resolved) = identifier.resolve(&partial) {
-            let reparsed = resolved
-                .to_string()
+            let rendered = identifier.to_string();
+            let reparsed = rendered
                 .parse::<Identifier>()
-                .expect("a resolved identifier to remain valid");
-            assert_eq!(reparsed, resolved);
+                .expect("a rendered identifier to remain valid");
+            assert_eq!(reparsed, identifier);
+
+            if let Ok(resolved) = identifier.resolve(&partial) {
+                let reparsed = resolved
+                    .to_string()
+                    .parse::<Identifier>()
+                    .expect("a resolved identifier to remain valid");
+                assert_eq!(reparsed, resolved);
+            }
         }
-    }
-});
+    });
+}

--- a/fuzz/fuzz_targets/repo_config.rs
+++ b/fuzz/fuzz_targets/repo_config.rs
@@ -1,26 +1,26 @@
-#![no_main]
-
+use afl::fuzz;
 use git_tool::engine::RepoConfig;
-use libfuzzer_sys::fuzz_target;
 
 mod common;
 
-fuzz_target!(|data: &[u8]| {
-    let input = common::bounded_bytes(data);
+fn main() {
+    fuzz!(|data: &[u8]| {
+        let input = common::bounded_bytes(data);
 
-    if let Ok(config) = RepoConfig::from_bytes(input) {
-        let canonical = config
-            .to_yaml()
-            .expect("a parsed repository configuration to serialize");
-        let hash = config
-            .hash()
-            .expect("a parsed repository configuration to hash");
-        let reparsed = RepoConfig::from_bytes(canonical.as_bytes())
-            .expect("a serialized repository configuration to parse");
+        if let Ok(config) = RepoConfig::from_bytes(input) {
+            let canonical = config
+                .to_yaml()
+                .expect("a parsed repository configuration to serialize");
+            let hash = config
+                .hash()
+                .expect("a parsed repository configuration to hash");
+            let reparsed = RepoConfig::from_bytes(canonical.as_bytes())
+                .expect("a serialized repository configuration to parse");
 
-        assert_eq!(canonical, reparsed.to_yaml().unwrap());
-        assert_eq!(hash, reparsed.hash().unwrap());
-        assert_eq!(hash.len(), 64);
-        assert!(hash.bytes().all(|byte| byte.is_ascii_hexdigit()));
-    }
-});
+            assert_eq!(canonical, reparsed.to_yaml().unwrap());
+            assert_eq!(hash, reparsed.hash().unwrap());
+            assert_eq!(hash.len(), 64);
+            assert!(hash.bytes().all(|byte| byte.is_ascii_hexdigit()));
+        }
+    });
+}

--- a/fuzz/fuzz_targets/search.rs
+++ b/fuzz/fuzz_targets/search.rs
@@ -1,27 +1,27 @@
-#![no_main]
-
+use afl::fuzz;
 use git_tool::search;
-use libfuzzer_sys::fuzz_target;
 
 mod common;
 
-fuzz_target!(|data: &[u8]| {
-    let mut fields = common::fields(data).into_iter();
-    let pattern = fields.next().unwrap_or_default();
-    let mut values = fields.collect::<Vec<_>>();
-    values.push(pattern.clone());
+fn main() {
+    fuzz!(|data: &[u8]| {
+        let mut fields = common::fields(data).into_iter();
+        let pattern = fields.next().unwrap_or_default();
+        let mut values = fields.collect::<Vec<_>>();
+        values.push(pattern.clone());
 
-    let filtered = search::matches(&pattern, values.clone());
-    let ranked = search::best_matches(&pattern, values.clone());
-    let matched_by_any = search::matches_any(&[pattern.as_str()], values.clone());
+        let filtered = search::matches(&pattern, values.clone());
+        let ranked = search::best_matches(&pattern, values.clone());
+        let matched_by_any = search::matches_any(&[pattern.as_str()], values.clone());
 
-    assert_eq!(filtered, matched_by_any);
-    assert!(search::fuzzy_matches(&pattern, &pattern));
-    assert!(filtered.contains(&pattern));
+        assert_eq!(filtered, matched_by_any);
+        assert!(search::fuzzy_matches(&pattern, &pattern));
+        assert!(filtered.contains(&pattern));
 
-    let mut filtered_sorted = filtered;
-    let mut ranked_sorted = ranked.clone();
-    filtered_sorted.sort();
-    ranked_sorted.sort();
-    assert_eq!(filtered_sorted, ranked_sorted);
-});
+        let mut filtered_sorted = filtered;
+        let mut ranked_sorted = ranked.clone();
+        filtered_sorted.sort();
+        ranked_sorted.sort();
+        assert_eq!(filtered_sorted, ranked_sorted);
+    });
+}

--- a/fuzz/fuzz_targets/tasks.rs
+++ b/fuzz/fuzz_targets/tasks.rs
@@ -1,58 +1,58 @@
-#![no_main]
-
+use afl::fuzz;
 use git_tool::{
     engine::{Config, Core, Repo},
     git,
     tasks::{GitBranchDelete, GitCheckout, GitInit, GitSwitch, Task},
 };
-use libfuzzer_sys::fuzz_target;
 
 mod common;
 
-fuzz_target!(|data: &[u8]| {
-    common::runtime().block_on(async {
-        let temp = tempfile::tempdir().expect("a temporary repository directory");
-        let repo = Repo::new("local:fuzz/repository", temp.path().to_path_buf());
-        let config = Config::default().with_dev_directory(temp.path());
-        let core = Core::builder().with_config(config).build();
+fn main() {
+    fuzz!(|data: &[u8]| {
+        common::runtime().block_on(async {
+            let temp = tempfile::tempdir().expect("a temporary repository directory");
+            let repo = Repo::new("local:fuzz/repository", temp.path().to_path_buf());
+            let config = Config::default().with_dev_directory(temp.path());
+            let core = Core::builder().with_config(config).build();
 
-        GitInit {}
-            .apply_repo(&core, &repo)
-            .await
-            .expect("the git-init task to succeed");
+            GitInit {}
+                .apply_repo(&core, &repo)
+                .await
+                .expect("the git-init task to succeed");
 
-        for (opcode, branch) in common::operations(data) {
-            match opcode % 4 {
-                0 => {
-                    let _ = GitCheckout { branch: &branch }
+            for (opcode, branch) in common::operations(data) {
+                match opcode % 4 {
+                    0 => {
+                        let _ = GitCheckout { branch: &branch }
+                            .apply_repo(&core, &repo)
+                            .await;
+                    }
+                    1 => {
+                        let _ = GitSwitch {
+                            branch,
+                            create_if_missing: true,
+                        }
                         .apply_repo(&core, &repo)
                         .await;
-                }
-                1 => {
-                    let _ = GitSwitch {
-                        branch,
-                        create_if_missing: true,
                     }
-                    .apply_repo(&core, &repo)
-                    .await;
-                }
-                2 => {
-                    let _ = GitSwitch {
-                        branch,
-                        create_if_missing: false,
+                    2 => {
+                        let _ = GitSwitch {
+                            branch,
+                            create_if_missing: false,
+                        }
+                        .apply_repo(&core, &repo)
+                        .await;
                     }
-                    .apply_repo(&core, &repo)
-                    .await;
+                    _ => {
+                        let _ = GitBranchDelete { branch }.apply_repo(&core, &repo).await;
+                    }
                 }
-                _ => {
-                    let _ = GitBranchDelete { branch }.apply_repo(&core, &repo).await;
-                }
-            }
 
-            assert!(temp.path().join(".git").is_dir());
-            git::git_branches(temp.path())
-                .await
-                .expect("the task-managed repository to remain queryable");
-        }
+                assert!(temp.path().join(".git").is_dir());
+                git::git_branches(temp.path())
+                    .await
+                    .expect("the task-managed repository to remain queryable");
+            }
+        });
     });
-});
+}

--- a/fuzz/fuzz_targets/templates.rs
+++ b/fuzz/fuzz_targets/templates.rs
@@ -1,64 +1,64 @@
-#![no_main]
-
+use afl::fuzz;
 use git_tool::engine::{render, render_list};
 use gotmpl::tmap;
-use libfuzzer_sys::fuzz_target;
 
 mod common;
 
-fuzz_target!(|data: &[u8]| {
-    let mut fields = data.splitn(3, |byte| *byte == 0);
-    let template = common::bounded_text(fields.next().unwrap_or_default());
-    let name = common::bounded_text(fields.next().unwrap_or_default());
-    let value = common::bounded_text(fields.next().unwrap_or_default());
-    let selector = data.first().copied().unwrap_or_default() as usize;
-    let literal = template.replace(['{', '}'], "_");
-    let context = tmap! {
-        "Name" => name.clone(),
-        "Value" => value.clone(),
-        "Enabled" => selector.is_multiple_of(2),
-        "Count" => selector as i64,
-        "Empty" => gotmpl::Value::Nil,
-        "Items" => vec![name, value.clone()],
-        "Nested" => tmap! {
-            "Value" => value,
-        },
-    };
+fn main() {
+    fuzz!(|data: &[u8]| {
+        let mut fields = data.splitn(3, |byte| *byte == 0);
+        let template = common::bounded_text(fields.next().unwrap_or_default());
+        let name = common::bounded_text(fields.next().unwrap_or_default());
+        let value = common::bounded_text(fields.next().unwrap_or_default());
+        let selector = data.first().copied().unwrap_or_default() as usize;
+        let literal = template.replace(['{', '}'], "_");
+        let context = tmap! {
+            "Name" => name.clone(),
+            "Value" => value.clone(),
+            "Enabled" => selector.is_multiple_of(2),
+            "Count" => selector as i64,
+            "Empty" => gotmpl::Value::Nil,
+            "Items" => vec![name, value.clone()],
+            "Nested" => tmap! {
+                "Value" => value,
+            },
+        };
 
-    if let Ok(rendered) = render(&template, context.clone()) {
-        assert_eq!(render(&template, context.clone()).unwrap(), rendered);
-        assert_eq!(
-            render_list(vec![template, "literal".to_string()], context.clone()).unwrap(),
-            vec![rendered, "literal".to_string()]
-        );
-    }
+        if let Ok(rendered) = render(&template, context.clone()) {
+            assert_eq!(render(&template, context.clone()).unwrap(), rendered);
+            assert_eq!(
+                render_list(vec![template, "literal".to_string()], context.clone()).unwrap(),
+                vec![rendered, "literal".to_string()]
+            );
+        }
 
-    let structured_templates = [
-        "{{ $root := . }}{{ if .Enabled }}{{ $root.Name }}{{ else }}{{ .Nested.Value }}{{ end }}",
-        "{{ range $index, $item := .Items }}{{ $index }}={{ $item }};{{ else }}empty{{ end }}",
-        "{{ with .Nested }}{{ .Value | printf \"%q\" }}{{ else }}empty{{ end }}",
-        "{{/* braces {{ }} and Unicode 世界 inside a comment */}}{{ len .Items }}:{{ index .Items 0 }}",
-        "{{ if and .Enabled (ne .Count 0) }}enabled{{ else if .Empty }}nil{{ else }}disabled{{ end }}",
-        "{{ $value := .Nested.Value }}{{ printf \"%s/%d\" $value .Count }}",
-        "{{ .Empty.Field }}",
-        "{{ .Name.Field }}",
-    ];
-    let structured_template = structured_templates[selector % structured_templates.len()];
-    let structured_result = render(structured_template, context.clone());
-    if let Ok(rendered) = structured_result {
-        assert_eq!(
-            render(structured_template, context.clone()).unwrap(),
-            rendered
-        );
-        assert_eq!(
-            render_list(vec![structured_template], context.clone()).unwrap(),
-            vec![rendered]
-        );
-    }
+        let structured_templates = [
+            "{{ $root := . }}{{ if .Enabled }}{{ $root.Name }}{{ else }}{{ .Nested.Value }}{{ end }}",
+            "{{ range $index, $item := .Items }}{{ $index }}={{ $item }};{{ else }}empty{{ end }}",
+            "{{ with .Nested }}{{ .Value | printf \"%q\" }}{{ else }}empty{{ end }}",
+            "{{/* braces {{ }} and Unicode 世界 inside a comment */}}{{ len .Items }}:{{ index .Items 0 }}",
+            "{{ if and .Enabled (ne .Count 0) }}enabled{{ else if .Empty }}nil{{ else }}disabled{{ end }}",
+            "{{ $value := .Nested.Value }}{{ printf \"%s/%d\" $value .Count }}",
+            "{{ .Empty.Field }}",
+            "{{ .Name.Field }}",
+        ];
+        let structured_template = structured_templates[selector % structured_templates.len()];
+        let structured_result = render(structured_template, context.clone());
+        if let Ok(rendered) = structured_result {
+            assert_eq!(
+                render(structured_template, context.clone()).unwrap(),
+                rendered
+            );
+            assert_eq!(
+                render_list(vec![structured_template], context.clone()).unwrap(),
+                vec![rendered]
+            );
+        }
 
-    let trim_template = format!("{literal} \t\r\n{{{{- .Value -}}}}\n\t {literal}");
-    assert_eq!(
-        render(&trim_template, context).unwrap(),
-        format!("{}{value}{}", literal.trim_end(), literal.trim_start())
-    );
-});
+        let trim_template = format!("{literal} \t\r\n{{{{- .Value -}}}}\n\t {literal}");
+        assert_eq!(
+            render(&trim_template, context).unwrap(),
+            format!("{}{value}{}", literal.trim_end(), literal.trim_start())
+        );
+    });
+}

--- a/scripts/fuzz
+++ b/scripts/fuzz
@@ -6,7 +6,7 @@ target="${1:-templates}"
 duration="${2:-60}"
 
 if [[ ! "$duration" =~ ^[0-9]+$ ]]; then
-    echo "Usage: ./scripts/fuzz [target] [seconds] [libFuzzer options...]" >&2
+    echo "Usage: ./scripts/fuzz [target] [seconds] [afl-fuzz options...]" >&2
     exit 2
 fi
 
@@ -19,28 +19,43 @@ if [[ ! -f "fuzz/fuzz_targets/${target}.rs" ]]; then
     exit 2
 fi
 
-if ! cargo +nightly --version >/dev/null 2>&1; then
-    echo "Nightly Rust is required. Install it with: rustup toolchain install nightly" >&2
+if ! command -v cargo-afl >/dev/null 2>&1; then
+    echo "cargo-afl is required. Install it with: cargo install cargo-afl" >&2
     exit 1
 fi
 
-if ! command -v cargo-fuzz >/dev/null 2>&1; then
-    echo "cargo-fuzz is required. Install it with: cargo install cargo-fuzz" >&2
-    exit 1
-fi
-
-mkdir -p "fuzz/corpus-output/${target}"
-
-cargo_args=(+nightly fuzz run)
+# Build the AFL-instrumented target binary.
+build_args=(afl build --release --manifest-path fuzz/Cargo.toml --bin "$target")
 if [[ -n "${CARGO_BUILD_TARGET:-}" ]]; then
-    cargo_args+=(--target "$CARGO_BUILD_TARGET")
+    build_args+=(--target "$CARGO_BUILD_TARGET")
+fi
+cargo "${build_args[@]}"
+
+if [[ -n "${CARGO_BUILD_TARGET:-}" ]]; then
+    binary="fuzz/target/${CARGO_BUILD_TARGET}/release/${target}"
+else
+    binary="fuzz/target/release/${target}"
 fi
 
-if [[ -n "${FUZZ_SANITIZER:-}" ]]; then
-    cargo_args+=(--sanitizer "$FUZZ_SANITIZER")
-elif [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
-    echo "Apple Silicon detected; disabling sanitizers to avoid the current linker incompatibility." >&2
-    cargo_args+=(--sanitizer none)
+# The checked-in corpus provides read-only seeds; AFL writes its state and any
+# discovered crashes to the (git-ignored) output directory.
+input_dir="fuzz/corpus/${target}"
+output_dir="fuzz/corpus-output/${target}"
+
+# AFL refuses to start without at least one seed input, so synthesise one when
+# the checked-in corpus is empty.
+if [[ -z "$(ls -A "$input_dir" 2>/dev/null || true)" ]]; then
+    input_dir="$(mktemp -d)"
+    printf '\0' >"${input_dir}/seed"
+fi
+
+# Resume an existing session when one is already present, otherwise start fresh.
+if [[ -d "${output_dir}/default/queue" ]]; then
+    afl_input=(-i -)
+else
+    rm -rf "$output_dir"
+    mkdir -p "$output_dir"
+    afl_input=(-i "$input_dir")
 fi
 
 if (( $# >= 2 )); then
@@ -49,10 +64,25 @@ else
     shift $#
 fi
 
-exec cargo "${cargo_args[@]}" \
-    "$target" \
-    "fuzz/corpus-output/${target}" \
-    "fuzz/corpus/${target}" -- \
-    -max_total_time="$duration" \
-    -timeout=10 \
-    "$@"
+# Keep AFL non-interactive so it runs cleanly in CI and on developer machines
+# where the kernel core pattern / CPU governor cannot be reconfigured.
+export AFL_SKIP_CPUFREQ="${AFL_SKIP_CPUFREQ:-1}"
+export AFL_NO_AFFINITY="${AFL_NO_AFFINITY:-1}"
+export AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES="${AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES:-1}"
+# Stop as soon as a reproducible crash is found so failures surface quickly.
+export AFL_BENCH_UNTIL_CRASH="${AFL_BENCH_UNTIL_CRASH:-1}"
+
+cargo afl fuzz \
+    "${afl_input[@]}" \
+    -o "$output_dir" \
+    -V "$duration" \
+    "$@" \
+    -- "$binary"
+
+crashes_dir="${output_dir}/default/crashes"
+if compgen -G "${crashes_dir}/id:*" >/dev/null 2>&1; then
+    echo "Fuzzing found crashes in ${crashes_dir}:" >&2
+    ls -1 "${crashes_dir}" >&2
+    echo "Reproduce with: cargo afl run --release --manifest-path fuzz/Cargo.toml --bin ${target} < ${crashes_dir}/<crash-file>" >&2
+    exit 1
+fi


### PR DESCRIPTION
Port the fuzz harness from libFuzzer/cargo-fuzz to AFL++/cargo-afl:
- Swap libfuzzer-sys for the afl crate and wrap each target's fuzz_target!
  closure in a main() using afl::fuzz!.
- Rewrite scripts/fuzz to build with cargo afl build and drive cargo afl
  fuzz, using fuzz/corpus as read-only seeds and fuzz/corpus-output for AFL
  state/crashes, and fail on discovered crashes.
- Update the Fuzz workflow to stable Rust + cargo-afl and upload crashes.
- Refresh fuzz/README.md and drop the unused fuzz/artifacts gitignore entry.