### PR TITLE
feat: Add AI coding assistants, editors, and code hosting services to the registry

### DIFF
--- a/registry/apps/aider.yaml
+++ b/registry/apps/aider.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
+name: Aider
+description: Launches the Aider AI pair programming assistant in a project directory.
+version: 1.0.0
+configs:
+  - platform: any
+    app:
+      name: aider
+      command: aider

--- a/registry/apps/amp.yaml
+++ b/registry/apps/amp.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
+name: Amp
+description: Launches Sourcegraph's Amp coding agent in a project directory.
+version: 1.0.0
+configs:
+  - platform: windows
+    app:
+      name: amp
+      command: cmd.exe
+      args:
+        - "/Q"
+        - "/C"
+        - "amp"
+  - platform: linux
+    app:
+      name: amp
+      command: amp
+  - platform: darwin
+    app:
+      name: amp
+      command: amp

--- a/registry/apps/claude.yaml
+++ b/registry/apps/claude.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
+name: Claude Code
+description: Launches Anthropic's Claude Code assistant in a project directory.
+version: 1.0.0
+configs:
+  - platform: windows
+    app:
+      name: claude
+      command: cmd.exe
+      args:
+        - "/Q"
+        - "/C"
+        - "claude"
+  - platform: linux
+    app:
+      name: claude
+      command: claude
+  - platform: darwin
+    app:
+      name: claude
+      command: claude

--- a/registry/apps/codex.yaml
+++ b/registry/apps/codex.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
+name: Codex CLI
+description: Launches OpenAI's Codex CLI coding assistant in a project directory.
+version: 1.0.0
+configs:
+  - platform: windows
+    app:
+      name: codex
+      command: cmd.exe
+      args:
+        - "/Q"
+        - "/C"
+        - "codex"
+  - platform: linux
+    app:
+      name: codex
+      command: codex
+  - platform: darwin
+    app:
+      name: codex
+      command: codex

--- a/registry/apps/copilot-cli.yaml
+++ b/registry/apps/copilot-cli.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
+name: GitHub Copilot CLI
+description: Launches the GitHub Copilot CLI coding agent in a project directory.
+version: 1.0.0
+configs:
+  - platform: windows
+    app:
+      name: copilot
+      command: cmd.exe
+      args:
+        - "/Q"
+        - "/C"
+        - "copilot"
+  - platform: linux
+    app:
+      name: copilot
+      command: copilot
+  - platform: darwin
+    app:
+      name: copilot
+      command: copilot

--- a/registry/apps/cursor.yaml
+++ b/registry/apps/cursor.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
+name: Cursor
+description: Launches the Cursor AI code editor in a project directory.
+version: 1.0.0
+configs:
+  - platform: windows
+    app:
+      name: cursor
+      command: cmd.exe
+      args:
+        - "/Q"
+        - "/C"
+        - "cursor.cmd ."
+  - platform: linux
+    app:
+      name: cursor
+      command: cursor
+      args:
+        - "."
+  - platform: darwin
+    app:
+      name: cursor
+      command: cursor
+      args:
+        - "."

--- a/registry/apps/emacs.yaml
+++ b/registry/apps/emacs.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
+name: Emacs
+description: Launches the Emacs text editor in a project directory.
+version: 1.0.0
+configs:
+  - platform: any
+    app:
+      name: emacs
+      command: emacs

--- a/registry/apps/fleet.yaml
+++ b/registry/apps/fleet.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
+name: Fleet
+description: Launches the JetBrains Fleet editor in a project directory.
+version: 1.0.0
+configs:
+  - platform: windows
+    app:
+      name: fleet
+      command: cmd.exe
+      args:
+        - "/Q"
+        - "/C"
+        - "fleet.cmd ."
+  - platform: linux
+    app:
+      name: fleet
+      command: fleet
+      args:
+        - "."
+  - platform: darwin
+    app:
+      name: fleet
+      command: fleet
+      args:
+        - "."

--- a/registry/apps/gemini.yaml
+++ b/registry/apps/gemini.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
+name: Gemini CLI
+description: Launches Google's Gemini CLI coding assistant in a project directory.
+version: 1.0.0
+configs:
+  - platform: windows
+    app:
+      name: gemini
+      command: cmd.exe
+      args:
+        - "/Q"
+        - "/C"
+        - "gemini"
+  - platform: linux
+    app:
+      name: gemini
+      command: gemini
+  - platform: darwin
+    app:
+      name: gemini
+      command: gemini

--- a/registry/apps/helix.yaml
+++ b/registry/apps/helix.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
+name: Helix
+description: Launches the Helix text editor in a project directory.
+version: 1.0.0
+configs:
+  - platform: any
+    app:
+      name: hx
+      command: hx

--- a/registry/apps/intellij.yaml
+++ b/registry/apps/intellij.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
+name: IntelliJ IDEA
+description: Launches JetBrains IntelliJ IDEA in a project directory.
+version: 1.0.0
+configs:
+  - platform: windows
+    app:
+      name: idea
+      command: cmd.exe
+      args:
+        - "/Q"
+        - "/C"
+        - "idea.cmd ."
+  - platform: linux
+    app:
+      name: idea
+      command: idea
+      args:
+        - "."
+  - platform: darwin
+    app:
+      name: idea
+      command: idea
+      args:
+        - "."

--- a/registry/apps/nano.yaml
+++ b/registry/apps/nano.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
+name: Nano
+description: Launches the GNU nano text editor in a project directory.
+version: 1.0.0
+configs:
+  - platform: any
+    app:
+      name: nano
+      command: nano

--- a/registry/apps/neovim.yaml
+++ b/registry/apps/neovim.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
+name: Neovim
+description: Launches the Neovim text editor in a project directory.
+version: 1.0.0
+configs:
+  - platform: any
+    app:
+      name: nvim
+      command: nvim

--- a/registry/apps/opencode.yaml
+++ b/registry/apps/opencode.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
+name: opencode
+description: Launches the opencode AI coding agent in a project directory.
+version: 1.0.0
+configs:
+  - platform: windows
+    app:
+      name: opencode
+      command: cmd.exe
+      args:
+        - "/Q"
+        - "/C"
+        - "opencode"
+  - platform: linux
+    app:
+      name: opencode
+      command: opencode
+  - platform: darwin
+    app:
+      name: opencode
+      command: opencode

--- a/registry/apps/qwen.yaml
+++ b/registry/apps/qwen.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
+name: Qwen Code
+description: Launches the Qwen Code AI coding assistant in a project directory.
+version: 1.0.0
+configs:
+  - platform: windows
+    app:
+      name: qwen
+      command: cmd.exe
+      args:
+        - "/Q"
+        - "/C"
+        - "qwen"
+  - platform: linux
+    app:
+      name: qwen
+      command: qwen
+  - platform: darwin
+    app:
+      name: qwen
+      command: qwen

--- a/registry/apps/sublime-text.yaml
+++ b/registry/apps/sublime-text.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
+name: Sublime Text
+description: Launches the Sublime Text editor in a project directory.
+version: 1.0.0
+configs:
+  - platform: windows
+    app:
+      name: subl
+      command: cmd.exe
+      args:
+        - "/Q"
+        - "/C"
+        - "subl.exe ."
+  - platform: linux
+    app:
+      name: subl
+      command: subl
+      args:
+        - "."
+  - platform: darwin
+    app:
+      name: subl
+      command: subl
+      args:
+        - "."

--- a/registry/apps/vim.yaml
+++ b/registry/apps/vim.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
+name: Vim
+description: Launches the Vim text editor in a project directory.
+version: 1.0.0
+configs:
+  - platform: any
+    app:
+      name: vim
+      command: vim

--- a/registry/apps/windsurf.yaml
+++ b/registry/apps/windsurf.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
+name: Windsurf
+description: Launches the Windsurf AI code editor in a project directory.
+version: 1.0.0
+configs:
+  - platform: windows
+    app:
+      name: windsurf
+      command: cmd.exe
+      args:
+        - "/Q"
+        - "/C"
+        - "windsurf.cmd ."
+  - platform: linux
+    app:
+      name: windsurf
+      command: windsurf
+      args:
+        - "."
+  - platform: darwin
+    app:
+      name: windsurf
+      command: windsurf
+      args:
+        - "."

--- a/registry/apps/zed.yaml
+++ b/registry/apps/zed.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v1/template.schema.json
+name: Zed
+description: Launches the Zed code editor in a project directory.
+version: 1.0.0
+configs:
+  - platform: linux
+    app:
+      name: zed
+      command: zed
+      args:
+        - "."
+  - platform: darwin
+    app:
+      name: zed
+      command: zed
+      args:
+        - "."

--- a/registry/services/codeberg.yaml
+++ b/registry/services/codeberg.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v2/template.schema.json
+name: Codeberg
+description: Adds support for managing Codeberg repositories through Git-Tool.
+version: 1.0.0
+configs:
+  - platform: any
+    service:
+      name: codeberg.org
+      website: "https://codeberg.org/{{ .Repo.FullName }}"
+      gitUrl: "git@codeberg.org:{{ .Repo.FullName }}.git"
+      pattern: "*/*"

--- a/registry/services/gitea.yaml
+++ b/registry/services/gitea.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v2/template.schema.json
+name: Gitea
+description: Adds support for managing repositories hosted on gitea.com through Git-Tool.
+version: 1.0.0
+configs:
+  - platform: any
+    service:
+      name: gitea.com
+      website: "https://gitea.com/{{ .Repo.FullName }}"
+      gitUrl: "git@gitea.com:{{ .Repo.FullName }}.git"
+      pattern: "*/*"

--- a/registry/services/gitee.yaml
+++ b/registry/services/gitee.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v2/template.schema.json
+name: Gitee
+description: Adds support for managing Gitee repositories through Git-Tool.
+version: 1.0.0
+configs:
+  - platform: any
+    service:
+      name: gitee.com
+      website: "https://gitee.com/{{ .Repo.FullName }}"
+      gitUrl: "git@gitee.com:{{ .Repo.FullName }}.git"
+      pattern: "*/*"

--- a/registry/services/sourcehut.yaml
+++ b/registry/services/sourcehut.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://schemas.sierrasoftworks.com/git-tool/v2/template.schema.json
+name: SourceHut
+description: Adds support for managing SourceHut repositories through Git-Tool.
+version: 1.0.0
+configs:
+  - platform: any
+    service:
+      name: git.sr.ht
+      website: "https://git.sr.ht/{{ .Repo.FullName }}"
+      gitUrl: "git@git.sr.ht:{{ .Repo.FullName }}"
+      pattern: "*/*"


### PR DESCRIPTION
Extends the Git-Tool registry with a broad set of example apps and services that users can install via `gt config add`.

### Apps — AI coding assistants
- Claude Code, OpenAI Codex CLI, opencode, Gemini CLI, GitHub Copilot CLI, Sourcegraph Amp, Qwen Code, Aider

### Apps — editors
- Cursor, Windsurf, Zed, Sublime Text, IntelliJ IDEA, JetBrains Fleet, Neovim, Vim, Emacs, Helix, nano

### Services — code hosting
- Codeberg, Gitea, SourceHut, Gitee

### Notes
- npm-based CLIs and GUI editors use a Windows `cmd.exe /Q /C` wrapper (matching `vscode.yaml`) so `.cmd` shims resolve, since Git-Tool spawns commands directly. Terminal editors use `platform: any`.
- `darwin` entries are included so the templates also install on macOS.
- New services follow the SSH-based, no-API style of `gitlab`/`bitbucket` (only `GitHub/v3` supports the online API used by `gt new`).
