### PR TITLE
feat: Add GitLab, Gitea/Forgejo and BitBucket online services

### DIFF
--- a/docs/config/services.md
+++ b/docs/config/services.md
@@ -133,3 +133,15 @@ api:
 - `GitHub/v3` is used to communicate with a GitHub server supporting the v3 API. Public GitHub uses
   `https://api.github.com` as its endpoint while a private GitHub Enterprise instance uses
   `https://github.example.com/api/v3`.
+- `GitLab/v4` is used to communicate with a GitLab server supporting the v4 REST API. Public GitLab uses
+  `https://gitlab.com/api/v4` as its endpoint while a self-managed instance uses
+  `https://gitlab.example.com/api/v4`. Authentication uses a Personal Access Token with the `api` scope.
+- `Gitea/v1` is used to communicate with a Gitea or Forgejo server (including Codeberg) supporting the v1
+  API. Gitea.com uses `https://gitea.com/api/v1`, Codeberg uses `https://codeberg.org/api/v1`, and a
+  self-hosted instance uses `https://gitea.example.com/api/v1`. Authentication uses an Access Token with
+  the `repository` (and, for organizations, `organization`) scope.
+- `BitBucket/2.0` is used to communicate with BitBucket Cloud's 2.0 REST API at
+  `https://api.bitbucket.org/2.0`. Authentication accepts either an App Password provided as
+  `username:app_password` (used with HTTP Basic authentication) or a standalone Access Token (used with
+  Bearer authentication). BitBucket does not support transferring a repository between workspaces through
+  its API, so [`gt move`](../commands/repos.md#move) can only rename repositories within the same workspace.

--- a/registry/services/bitbucket.yaml
+++ b/registry/services/bitbucket.yaml
@@ -9,3 +9,6 @@ configs:
       website: "https://bitbucket.org/{{ .Repo.FullName }}"
       gitUrl: "git@bitbucket.org:{{ .Repo.FullName }}.git"
       pattern: "*/*"
+      api:
+        kind: BitBucket/2.0
+        url: https://api.bitbucket.org/2.0

--- a/registry/services/codeberg.yaml
+++ b/registry/services/codeberg.yaml
@@ -9,3 +9,6 @@ configs:
       website: "https://codeberg.org/{{ .Repo.FullName }}"
       gitUrl: "git@codeberg.org:{{ .Repo.FullName }}.git"
       pattern: "*/*"
+      api:
+        kind: Gitea/v1
+        url: https://codeberg.org/api/v1

--- a/registry/services/gitea.yaml
+++ b/registry/services/gitea.yaml
@@ -9,3 +9,6 @@ configs:
       website: "https://gitea.com/{{ .Repo.FullName }}"
       gitUrl: "git@gitea.com:{{ .Repo.FullName }}.git"
       pattern: "*/*"
+      api:
+        kind: Gitea/v1
+        url: https://gitea.com/api/v1

--- a/registry/services/gitlab.yaml
+++ b/registry/services/gitlab.yaml
@@ -9,3 +9,6 @@ configs:
       website: "https://gitlab.com/{{ .Repo.FullName }}"
       gitUrl: "git@gitlab.com:{{ .Repo.FullName }}.git"
       pattern: "*/*"
+      api:
+        kind: GitLab/v4
+        url: https://gitlab.com/api/v4

--- a/src/online/service/bitbucket.rs
+++ b/src/online/service/bitbucket.rs
@@ -1,0 +1,551 @@
+use super::*;
+use base64::prelude::{BASE64_STANDARD, Engine};
+use reqwest::{Method, StatusCode};
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+
+#[derive(Default)]
+pub struct BitBucketService {}
+
+#[async_trait]
+impl OnlineService for BitBucketService {
+    fn handles(&self, service: &Service) -> bool {
+        service
+            .api
+            .as_ref()
+            .map(|api| api.kind == "BitBucket/2.0")
+            .unwrap_or(false)
+    }
+
+    fn auth_instructions(&self) -> String {
+        r#"
+BitBucket Cloud supports two kinds of credentials which you can use with Git-Tool:
+
+  1. App Passwords (recommended): create one at https://bitbucket.org/account/settings/app-passwords/
+     with the "Repositories: Read, Write, Admin" permissions, then enter it in the form
+     `username:app_password` (using your BitBucket username).
+
+  2. Access Tokens: create a Workspace, Project or Repository Access Token with the
+     "repository:admin" scope and paste the token on its own.
+
+Git-Tool will automatically use HTTP Basic authentication when you provide a `username:app_password`
+value and Bearer authentication when you provide a standalone access token."#
+            .trim()
+            .into()
+    }
+
+    async fn test(&self, core: &Core, service: &Service) -> Result<(), human_errors::Error> {
+        let uri = format!("{}/user", self.api_url(service));
+        let resp: Result<UserProfile, BitBucketErrorResponse> = self
+            .make_request(
+                core,
+                service,
+                Method::GET,
+                &uri,
+                Vec::new(),
+                vec![StatusCode::OK],
+            )
+            .await?;
+
+        match resp {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    #[tracing::instrument(err, skip(self, core))]
+    async fn is_created(
+        &self,
+        core: &Core,
+        service: &Service,
+        repo: &Repo,
+    ) -> Result<bool, human_errors::Error> {
+        let uri = format!(
+            "{}/repositories/{}/{}",
+            self.api_url(service),
+            repo.namespace,
+            repo.name
+        );
+
+        let resp: Result<RepoResponse, BitBucketErrorResponse> = self
+            .make_request(
+                core,
+                service,
+                Method::GET,
+                &uri,
+                Vec::new(),
+                vec![StatusCode::OK],
+            )
+            .await?;
+
+        match resp {
+            Ok(_) => Ok(true),
+            Err(e) if e.http_status_code == StatusCode::NOT_FOUND => Ok(false),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    #[tracing::instrument(err, skip(self, core))]
+    async fn ensure_created(
+        &self,
+        core: &Core,
+        service: &Service,
+        repo: &Repo,
+    ) -> Result<(), human_errors::Error> {
+        let uri = format!(
+            "{}/repositories/{}/{}",
+            self.api_url(service),
+            repo.namespace,
+            repo.name
+        );
+
+        let body = serde_json::to_vec(&json!({
+            "scm": "git",
+            "is_private": core
+                .config()
+                .get_features()
+                .has(features::CREATE_REMOTE_PRIVATE),
+        }))
+        .wrap_system_err(
+            "Failed to serialize repository information for submission to BitBucket as part of repo creation.", &[
+                "Please report this issue to us by creating a new GitHub issue.",
+                "Try creating your repository with `git-tool new --no-create-remote` and then pushing it to BitBucket manually."
+            ])?;
+
+        let resp: Result<RepoResponse, BitBucketErrorResponse> = self
+            .make_request(
+                core,
+                service,
+                Method::POST,
+                &uri,
+                body,
+                vec![StatusCode::OK, StatusCode::CREATED],
+            )
+            .await?;
+
+        match resp {
+            Ok(_) => Ok(()),
+            Err(e) if e.already_exists() => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    #[tracing::instrument(err, skip(self, core))]
+    async fn move_repo(
+        &self,
+        core: &Core,
+        service: &Service,
+        source: &Repo,
+        destination: &Repo,
+    ) -> Result<(), human_errors::Error> {
+        // BitBucket Cloud's REST API only supports renaming a repository within the same
+        // workspace; there is no supported endpoint for transferring a repository between
+        // workspaces, so we surface a helpful error in that case.
+        if !source
+            .namespace
+            .eq_ignore_ascii_case(&destination.namespace)
+        {
+            return Err(human_errors::user(
+                format!(
+                    "BitBucket does not support moving the repository '{}' to a different workspace ('{}') through its API.",
+                    source.get_full_name(),
+                    destination.namespace
+                ),
+                &[
+                    "Move the repository to the new workspace manually using BitBucket's repository settings page, or keep it within the same workspace when renaming it.",
+                ],
+            ));
+        }
+
+        let uri = format!(
+            "{}/repositories/{}/{}",
+            self.api_url(service),
+            source.namespace,
+            source.name
+        );
+
+        let body = serde_json::to_vec(&json!({
+            "name": destination.name,
+        }))
+        .wrap_system_err(
+            "Failed to serialize repository information for submission to BitBucket as part of repo rename.", &[
+                "Please report this issue to us by creating a new GitHub issue.",
+                "Try renaming the repository manually on BitBucket using the repository settings page."
+            ])?;
+
+        let resp: Result<RepoResponse, BitBucketErrorResponse> = self
+            .make_request(core, service, Method::PUT, &uri, body, vec![StatusCode::OK])
+            .await?;
+
+        match resp {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    #[tracing::instrument(err, skip(self, core))]
+    async fn fork_repo(
+        &self,
+        core: &Core,
+        service: &Service,
+        source: &Repo,
+        destination: &Repo,
+        _default_branch_only: bool,
+    ) -> Result<(), human_errors::Error> {
+        let uri = format!(
+            "{}/repositories/{}/{}/forks",
+            self.api_url(service),
+            source.namespace,
+            source.name
+        );
+
+        let body = serde_json::to_vec(&json!({
+            "name": destination.name,
+            "workspace": {
+                "slug": destination.namespace,
+            },
+        }))
+        .wrap_system_err(
+            "Failed to serialize repository information for submission to BitBucket as part of repo fork.", &[
+                "Please report this issue to us by creating a new GitHub issue.",
+                "Try forking the repository manually on BitBucket using the repository page."
+            ])?;
+
+        let resp: Result<RepoResponse, BitBucketErrorResponse> = self
+            .make_request(
+                core,
+                service,
+                Method::POST,
+                &uri,
+                body,
+                vec![StatusCode::OK, StatusCode::CREATED],
+            )
+            .await?;
+
+        match resp {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+impl BitBucketService {
+    fn api_url(&self, service: &Service) -> String {
+        service
+            .api
+            .as_ref()
+            .map(|api| api.url.trim_end_matches('/').to_string())
+            .unwrap_or_default()
+    }
+
+    fn authorization_header(token: &str) -> String {
+        // App Passwords and API tokens are provided as `username:secret` and use HTTP Basic
+        // authentication, while standalone Access Tokens use Bearer authentication.
+        if token.contains(':') {
+            format!("Basic {}", BASE64_STANDARD.encode(token.as_bytes()))
+        } else {
+            format!("Bearer {token}")
+        }
+    }
+
+    async fn make_request<B: Into<reqwest::Body> + Clone, T: DeserializeOwned>(
+        &self,
+        core: &Core,
+        service: &Service,
+        method: Method,
+        uri: &str,
+        body: B,
+        acceptable: Vec<StatusCode>,
+    ) -> Result<Result<T, BitBucketErrorResponse>, human_errors::Error> {
+        let token = core.keychain().get_token(&service.name)?;
+
+        let headers = vec![
+            ("Accept", "application/json".to_string()),
+            ("Content-Type", "application/json".to_string()),
+            ("Authorization", Self::authorization_header(&token)),
+        ];
+
+        let (status, bytes) = request_with_retry(core, method, uri, &headers, body).await?;
+
+        if acceptable.contains(&status) {
+            let result = serde_json::from_slice(&bytes).wrap_system_err(
+                "We could not deserialize the response from BitBucket because it didn't match the expected response format.",
+                &["Please report this issue to us on GitHub with the trace ID for the command you were running so that we can investigate."],
+            )?;
+
+            return Ok(Ok(result));
+        }
+
+        let mut result: BitBucketErrorResponse = serde_json::from_slice(&bytes).unwrap_or_default();
+        result.http_status_code = status;
+        Ok(Err(result))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct UserProfile {
+    #[serde(default)]
+    pub username: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct RepoResponse {
+    #[serde(default)]
+    pub full_name: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct BitBucketErrorResponse {
+    #[serde(skip)]
+    pub http_status_code: StatusCode,
+
+    #[serde(default)]
+    pub error: BitBucketErrorBody,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[allow(dead_code)]
+struct BitBucketErrorBody {
+    #[serde(default)]
+    pub message: String,
+
+    #[serde(default)]
+    pub detail: String,
+}
+
+impl BitBucketErrorResponse {
+    fn already_exists(&self) -> bool {
+        self.http_status_code == StatusCode::BAD_REQUEST
+            && self.error.message.to_lowercase().contains("already exists")
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<Error> for BitBucketErrorResponse {
+    fn into(self) -> Error {
+        match self.http_status_code {
+            StatusCode::UNAUTHORIZED => human_errors::user(
+                "You have not provided a valid authentication token for BitBucket.",
+                &[
+                    "Create an App Password (entered as `username:app_password`) or an Access Token and add it using `git-tool auth <service>`.",
+                ],
+            ),
+            StatusCode::FORBIDDEN => human_errors::wrap_user(
+                format!("{self:?}"),
+                format!(
+                    "You do not have permission to perform this action on BitBucket: {}",
+                    self.error.message
+                ),
+                &[
+                    "Check that your App Password or Access Token includes the repository administration permissions and that you have access to this workspace.",
+                ],
+            ),
+            StatusCode::NOT_FOUND => human_errors::wrap_user(
+                format!("{self:?}"),
+                "We could not find the BitBucket workspace or repository you specified.",
+                &[
+                    "Check that you have specified the correct workspace in the repository name and try again.",
+                ],
+            ),
+            StatusCode::TOO_MANY_REQUESTS => human_errors::user(
+                "BitBucket has rate limited requests from your IP address.",
+                &["Please wait until BitBucket removes this rate limit before trying again."],
+            ),
+            status => human_errors::wrap_system(
+                format!("{self:?}"),
+                format!(
+                    "Received an HTTP {} {} response from BitBucket: {}",
+                    status.as_u16(),
+                    status.canonical_reason().unwrap_or_default(),
+                    self.error.message
+                ),
+                &[
+                    "Please read the error message below and decide if there is something you can do to fix the problem, or report it to us on GitHub.",
+                ],
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockall::predicate::eq;
+
+    fn service() -> Service {
+        Service {
+            name: "bitbucket".into(),
+            website: "https://bitbucket.org/{{ .Repo.FullName }}".into(),
+            git_url: "git@bitbucket.org:{{ .Repo.FullName }}.git".into(),
+            pattern: "*/*".into(),
+            api: Some(ServiceAPI {
+                kind: "BitBucket/2.0".into(),
+                url: "https://api.bitbucket.org/2.0".into(),
+            }),
+        }
+    }
+
+    fn core(mocks: Vec<MockHttpRoute>) -> Core {
+        Core::builder()
+            .with_default_config()
+            .with_mock_keychain(|mock| {
+                mock.expect_get_token()
+                    .with(eq("bitbucket"))
+                    .returning(|_| Ok("user:app_password".into()));
+            })
+            .with_mock_http_client(mocks)
+            .build()
+    }
+
+    #[test]
+    fn test_authorization_header() {
+        assert_eq!(
+            BitBucketService::authorization_header("user:app_password"),
+            format!("Basic {}", BASE64_STANDARD.encode("user:app_password"))
+        );
+        assert_eq!(
+            BitBucketService::authorization_header("access-token"),
+            "Bearer access-token"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_repo() {
+        let core = core(vec![MockHttpRoute::new(
+            "POST",
+            "https://api.bitbucket.org/2.0/repositories/myworkspace/user-repo",
+            200,
+            r#"{ "full_name": "myworkspace/user-repo" }"#,
+        )]);
+
+        let repo = Repo::new(
+            "bitbucket:myworkspace/user-repo",
+            std::path::PathBuf::from("/"),
+        );
+        BitBucketService::default()
+            .ensure_created(&core, &service(), &repo)
+            .await
+            .expect("No error should have been generated");
+    }
+
+    #[tokio::test]
+    async fn test_create_repo_exists() {
+        let core = core(vec![MockHttpRoute::new(
+            "POST",
+            "https://api.bitbucket.org/2.0/repositories/myworkspace/user-repo",
+            400,
+            r#"{ "type": "error", "error": { "message": "Repository with this Slug and Owner already exists." } }"#,
+        )]);
+
+        let repo = Repo::new(
+            "bitbucket:myworkspace/user-repo",
+            std::path::PathBuf::from("/"),
+        );
+        BitBucketService::default()
+            .ensure_created(&core, &service(), &repo)
+            .await
+            .expect("No error should have been generated");
+    }
+
+    #[tokio::test]
+    async fn test_is_created_yes() {
+        let core = core(vec![MockHttpRoute::new(
+            "GET",
+            "https://api.bitbucket.org/2.0/repositories/myworkspace/user-repo",
+            200,
+            r#"{ "full_name": "myworkspace/user-repo" }"#,
+        )]);
+
+        let repo = Repo::new(
+            "bitbucket:myworkspace/user-repo",
+            std::path::PathBuf::from("/"),
+        );
+        assert!(
+            BitBucketService::default()
+                .is_created(&core, &service(), &repo)
+                .await
+                .expect("No error should have been generated")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_is_created_no() {
+        let core = core(vec![MockHttpRoute::new(
+            "GET",
+            "https://api.bitbucket.org/2.0/repositories/myworkspace/user-repo",
+            404,
+            r#"{ "type": "error", "error": { "message": "Repository not found" } }"#,
+        )]);
+
+        let repo = Repo::new(
+            "bitbucket:myworkspace/user-repo",
+            std::path::PathBuf::from("/"),
+        );
+        assert!(
+            !BitBucketService::default()
+                .is_created(&core, &service(), &repo)
+                .await
+                .expect("No error should have been generated")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_move_same_workspace() {
+        let core = core(vec![MockHttpRoute::new(
+            "PUT",
+            "https://api.bitbucket.org/2.0/repositories/myworkspace/user-repo",
+            200,
+            r#"{ "full_name": "myworkspace/new-name" }"#,
+        )]);
+
+        let src = Repo::new(
+            "bitbucket:myworkspace/user-repo",
+            std::path::PathBuf::from("/"),
+        );
+        let dest = Repo::new(
+            "bitbucket:myworkspace/new-name",
+            std::path::PathBuf::from("/"),
+        );
+        BitBucketService::default()
+            .move_repo(&core, &service(), &src, &dest)
+            .await
+            .expect("No error should have been generated");
+    }
+
+    #[tokio::test]
+    async fn test_move_different_workspace_errors() {
+        let core = core(vec![]);
+
+        let src = Repo::new(
+            "bitbucket:myworkspace/user-repo",
+            std::path::PathBuf::from("/"),
+        );
+        let dest = Repo::new("bitbucket:other/new-name", std::path::PathBuf::from("/"));
+        BitBucketService::default()
+            .move_repo(&core, &service(), &src, &dest)
+            .await
+            .expect_err("An error should have been generated for a cross-workspace move");
+    }
+
+    #[tokio::test]
+    async fn test_fork_repo() {
+        let core = core(vec![MockHttpRoute::new(
+            "POST",
+            "https://api.bitbucket.org/2.0/repositories/other/user-repo/forks",
+            201,
+            r#"{ "full_name": "myworkspace/user-repo" }"#,
+        )]);
+
+        let src = Repo::new("bitbucket:other/user-repo", std::path::PathBuf::from("/"));
+        let dest = Repo::new(
+            "bitbucket:myworkspace/user-repo",
+            std::path::PathBuf::from("/"),
+        );
+        BitBucketService::default()
+            .fork_repo(&core, &service(), &src, &dest, true)
+            .await
+            .expect("No error should have been generated");
+    }
+}

--- a/src/online/service/gitea.rs
+++ b/src/online/service/gitea.rs
@@ -1,0 +1,611 @@
+use super::*;
+use reqwest::{Method, StatusCode};
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+
+#[derive(Default)]
+pub struct GiteaService {}
+
+#[async_trait]
+impl OnlineService for GiteaService {
+    fn handles(&self, service: &Service) -> bool {
+        service
+            .api
+            .as_ref()
+            .map(|api| api.kind == "Gitea/v1")
+            .unwrap_or(false)
+    }
+
+    fn auth_instructions(&self) -> String {
+        r#"
+Create a new Access Token from your account settings (Settings > Applications > Manage Access Tokens).
+Configure it with the following permissions:
+  - repository: Read and Write
+  - organization: Read and Write (only required if you create repositories under an organization)
+
+On gitea.com the token page is available at https://gitea.com/user/settings/applications and on Codeberg at https://codeberg.org/user/settings/applications. For a self-hosted Gitea or Forgejo instance, replace the domain with your instance's URL."#
+            .trim()
+            .into()
+    }
+
+    async fn test(&self, core: &Core, service: &Service) -> Result<(), human_errors::Error> {
+        self.get_current_username(core, service).await?;
+        Ok(())
+    }
+
+    #[tracing::instrument(err, skip(self, core))]
+    async fn is_created(
+        &self,
+        core: &Core,
+        service: &Service,
+        repo: &Repo,
+    ) -> Result<bool, human_errors::Error> {
+        let uri = format!("{}/repos/{}", self.api_url(service), repo.get_full_name());
+
+        let resp: Result<RepoResponse, GiteaErrorResponse> = self
+            .make_request(
+                core,
+                service,
+                Method::GET,
+                &uri,
+                Vec::new(),
+                vec![StatusCode::OK],
+            )
+            .await?;
+
+        match resp {
+            Ok(_) => Ok(true),
+            Err(e) if e.http_status_code == StatusCode::NOT_FOUND => Ok(false),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    #[tracing::instrument(err, skip(self, core))]
+    async fn ensure_created(
+        &self,
+        core: &Core,
+        service: &Service,
+        repo: &Repo,
+    ) -> Result<(), human_errors::Error> {
+        let current_user = self.get_current_username(core, service).await?;
+
+        let uri = if repo.namespace.eq_ignore_ascii_case(&current_user) {
+            format!("{}/user/repos", self.api_url(service))
+        } else {
+            format!("{}/orgs/{}/repos", self.api_url(service), &repo.namespace)
+        };
+
+        let body = serde_json::to_vec(&json!({
+            "name": repo.get_name(),
+            "private": core
+                .config()
+                .get_features()
+                .has(features::CREATE_REMOTE_PRIVATE),
+        }))
+        .wrap_system_err(
+            "Failed to serialize repository information for submission to Gitea as part of repo creation.", &[
+                "Please report this issue to us by creating a new GitHub issue.",
+                "Try creating your repository with `git-tool new --no-create-remote` and then pushing it to your Gitea server manually."
+            ])?;
+
+        let resp: Result<RepoResponse, GiteaErrorResponse> = self
+            .make_request(
+                core,
+                service,
+                Method::POST,
+                &uri,
+                body,
+                vec![StatusCode::CREATED],
+            )
+            .await?;
+
+        match resp {
+            Ok(_) => Ok(()),
+            Err(e) if e.http_status_code == StatusCode::CONFLICT => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    #[tracing::instrument(err, skip(self, core))]
+    async fn move_repo(
+        &self,
+        core: &Core,
+        service: &Service,
+        source: &Repo,
+        destination: &Repo,
+    ) -> Result<(), human_errors::Error> {
+        if source
+            .namespace
+            .eq_ignore_ascii_case(&destination.namespace)
+        {
+            self.rename_repo(
+                core,
+                service,
+                &source.namespace,
+                &source.name,
+                &destination.name,
+            )
+            .await?;
+        } else {
+            // Gitea's transfer endpoint moves the repository to a new owner but keeps its
+            // name, so we perform the transfer first and then rename the repository if the
+            // caller also asked for a new name.
+            let uri = format!(
+                "{}/repos/{}/{}/transfer",
+                self.api_url(service),
+                source.namespace,
+                source.name
+            );
+
+            let body = serde_json::to_vec(&json!({
+                "new_owner": destination.namespace,
+            }))
+            .wrap_system_err(
+                "Failed to serialize repository information for submission to Gitea as part of repo transfer.", &[
+                    "Please report this issue to us by creating a new GitHub issue.",
+                    "Try transferring the repository manually using your Gitea server's repository settings page."
+                ])?;
+
+            let resp: Result<RepoResponse, GiteaErrorResponse> = self
+                .make_request(
+                    core,
+                    service,
+                    Method::POST,
+                    &uri,
+                    body,
+                    vec![StatusCode::ACCEPTED, StatusCode::CREATED, StatusCode::OK],
+                )
+                .await?;
+
+            if let Err(e) = resp {
+                return Err(e.into());
+            }
+
+            if !source.name.eq_ignore_ascii_case(&destination.name) {
+                self.rename_repo(
+                    core,
+                    service,
+                    &destination.namespace,
+                    &source.name,
+                    &destination.name,
+                )
+                .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tracing::instrument(err, skip(self, core))]
+    async fn fork_repo(
+        &self,
+        core: &Core,
+        service: &Service,
+        source: &Repo,
+        destination: &Repo,
+        _default_branch_only: bool,
+    ) -> Result<(), human_errors::Error> {
+        let uri = format!(
+            "{}/repos/{}/{}/forks",
+            self.api_url(service),
+            source.namespace,
+            source.name
+        );
+
+        let current_user = self.get_current_username(core, service).await?;
+
+        let mut body_json = json!({
+            "name": destination.name,
+        });
+
+        if !destination.namespace.eq_ignore_ascii_case(&current_user)
+            && let serde_json::Value::Object(map) = &mut body_json
+        {
+            map.insert(
+                "organization".into(),
+                serde_json::Value::String(destination.namespace.clone()),
+            );
+        }
+
+        let body = serde_json::to_vec(&body_json).wrap_system_err(
+            "Failed to serialize repository information for submission to Gitea as part of repo fork.", &[
+                "Please report this issue to us by creating a new GitHub issue.",
+                "Try forking the repository manually using your Gitea server's repository page."
+            ])?;
+
+        let resp: Result<RepoResponse, GiteaErrorResponse> = self
+            .make_request(
+                core,
+                service,
+                Method::POST,
+                &uri,
+                body,
+                vec![StatusCode::ACCEPTED, StatusCode::CREATED, StatusCode::OK],
+            )
+            .await?;
+
+        match resp {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+impl GiteaService {
+    fn api_url(&self, service: &Service) -> String {
+        service
+            .api
+            .as_ref()
+            .map(|api| api.url.trim_end_matches('/').to_string())
+            .unwrap_or_default()
+    }
+
+    async fn get_current_username(
+        &self,
+        core: &Core,
+        service: &Service,
+    ) -> Result<String, human_errors::Error> {
+        let uri = format!("{}/user", self.api_url(service));
+        let user: Result<UserProfile, GiteaErrorResponse> = self
+            .make_request(
+                core,
+                service,
+                Method::GET,
+                &uri,
+                Vec::new(),
+                vec![StatusCode::OK],
+            )
+            .await?;
+
+        match user {
+            Ok(user) => Ok(user.login),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn rename_repo(
+        &self,
+        core: &Core,
+        service: &Service,
+        owner: &str,
+        name: &str,
+        new_name: &str,
+    ) -> Result<(), human_errors::Error> {
+        let uri = format!("{}/repos/{}/{}", self.api_url(service), owner, name);
+
+        let body = serde_json::to_vec(&json!({
+            "name": new_name,
+        }))
+        .wrap_system_err(
+            "Failed to serialize repository information for submission to Gitea as part of repo rename.", &[
+                "Please report this issue to us by creating a new GitHub issue.",
+                "Try renaming the repository manually using your Gitea server's repository settings page."
+            ])?;
+
+        let resp: Result<RepoResponse, GiteaErrorResponse> = self
+            .make_request(
+                core,
+                service,
+                Method::PATCH,
+                &uri,
+                body,
+                vec![StatusCode::OK],
+            )
+            .await?;
+
+        match resp {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn make_request<B: Into<reqwest::Body> + Clone, T: DeserializeOwned>(
+        &self,
+        core: &Core,
+        service: &Service,
+        method: Method,
+        uri: &str,
+        body: B,
+        acceptable: Vec<StatusCode>,
+    ) -> Result<Result<T, GiteaErrorResponse>, human_errors::Error> {
+        let token = core.keychain().get_token(&service.name)?;
+
+        let headers = vec![
+            ("Accept", "application/json".to_string()),
+            ("Content-Type", "application/json".to_string()),
+            ("Authorization", format!("token {token}")),
+        ];
+
+        let (status, bytes) = request_with_retry(core, method, uri, &headers, body).await?;
+
+        if acceptable.contains(&status) {
+            let result = serde_json::from_slice(&bytes).wrap_system_err(
+                "We could not deserialize the response from Gitea because it didn't match the expected response format.",
+                &["Please report this issue to us on GitHub with the trace ID for the command you were running so that we can investigate."],
+            )?;
+
+            return Ok(Ok(result));
+        }
+
+        let mut result: GiteaErrorResponse = serde_json::from_slice(&bytes).unwrap_or_default();
+        result.http_status_code = status;
+        Ok(Err(result))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct UserProfile {
+    pub login: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct RepoResponse {
+    pub id: u64,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[allow(dead_code)]
+struct GiteaErrorResponse {
+    #[serde(skip)]
+    pub http_status_code: StatusCode,
+
+    #[serde(default)]
+    pub message: String,
+
+    #[serde(default)]
+    pub url: String,
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<Error> for GiteaErrorResponse {
+    fn into(self) -> Error {
+        match self.http_status_code {
+            StatusCode::UNAUTHORIZED => human_errors::user(
+                "You have not provided a valid authentication token for your Gitea server.",
+                &[
+                    "Generate a valid Access Token with the `repository` scope from your account's applications settings and add it using `git-tool auth <service>`.",
+                ],
+            ),
+            StatusCode::FORBIDDEN => human_errors::wrap_user(
+                format!("{self:?}"),
+                format!(
+                    "You do not have permission to perform this action on your Gitea server: {}",
+                    self.message
+                ),
+                &[
+                    "Check that your access token has the `repository` (and, for organizations, `organization`) scope and that you have permission to manage this repository.",
+                ],
+            ),
+            StatusCode::NOT_FOUND => human_errors::wrap_user(
+                format!("{self:?}"),
+                "We could not find the Gitea organization or user you specified.",
+                &[
+                    "Check that you have specified the correct organization or user in the repository name and try again.",
+                ],
+            ),
+            StatusCode::TOO_MANY_REQUESTS => human_errors::user(
+                "Your Gitea server has rate limited requests from your IP address.",
+                &["Please wait until the rate limit is removed before trying again."],
+            ),
+            status => human_errors::wrap_system(
+                format!("{self:?}"),
+                format!(
+                    "Received an HTTP {} {} response from Gitea: {}",
+                    status.as_u16(),
+                    status.canonical_reason().unwrap_or_default(),
+                    self.message
+                ),
+                &[
+                    "Please read the error message below and decide if there is something you can do to fix the problem, or report it to us on GitHub.",
+                ],
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockall::predicate::eq;
+
+    fn service() -> Service {
+        Service {
+            name: "gitea".into(),
+            website: "https://gitea.com/{{ .Repo.FullName }}".into(),
+            git_url: "git@gitea.com:{{ .Repo.FullName }}.git".into(),
+            pattern: "*/*".into(),
+            api: Some(ServiceAPI {
+                kind: "Gitea/v1".into(),
+                url: "https://gitea.com/api/v1".into(),
+            }),
+        }
+    }
+
+    fn core(mocks: Vec<MockHttpRoute>) -> Core {
+        Core::builder()
+            .with_default_config()
+            .with_mock_keychain(|mock| {
+                mock.expect_get_token()
+                    .with(eq("gitea"))
+                    .returning(|_| Ok("test_token".into()));
+            })
+            .with_mock_http_client(mocks)
+            .build()
+    }
+
+    #[tokio::test]
+    async fn test_create_user_repo() {
+        let core = core(vec![
+            MockHttpRoute::new(
+                "GET",
+                "https://gitea.com/api/v1/user",
+                200,
+                r#"{ "login": "test" }"#,
+            ),
+            MockHttpRoute::new(
+                "POST",
+                "https://gitea.com/api/v1/user/repos",
+                201,
+                r#"{ "id": 1234 }"#,
+            ),
+        ]);
+
+        let repo = Repo::new("gitea:test/user-repo", std::path::PathBuf::from("/"));
+        GiteaService::default()
+            .ensure_created(&core, &service(), &repo)
+            .await
+            .expect("No error should have been generated");
+    }
+
+    #[tokio::test]
+    async fn test_create_org_repo() {
+        let core = core(vec![
+            MockHttpRoute::new(
+                "GET",
+                "https://gitea.com/api/v1/user",
+                200,
+                r#"{ "login": "test" }"#,
+            ),
+            MockHttpRoute::new(
+                "POST",
+                "https://gitea.com/api/v1/orgs/myorg/repos",
+                201,
+                r#"{ "id": 1234 }"#,
+            ),
+        ]);
+
+        let repo = Repo::new("gitea:myorg/user-repo", std::path::PathBuf::from("/"));
+        GiteaService::default()
+            .ensure_created(&core, &service(), &repo)
+            .await
+            .expect("No error should have been generated");
+    }
+
+    #[tokio::test]
+    async fn test_create_repo_exists() {
+        let core = core(vec![
+            MockHttpRoute::new(
+                "GET",
+                "https://gitea.com/api/v1/user",
+                200,
+                r#"{ "login": "test" }"#,
+            ),
+            MockHttpRoute::new(
+                "POST",
+                "https://gitea.com/api/v1/user/repos",
+                409,
+                r#"{ "message": "The repository with the same name already exists." }"#,
+            ),
+        ]);
+
+        let repo = Repo::new("gitea:test/user-repo", std::path::PathBuf::from("/"));
+        GiteaService::default()
+            .ensure_created(&core, &service(), &repo)
+            .await
+            .expect("No error should have been generated");
+    }
+
+    #[tokio::test]
+    async fn test_is_created_yes() {
+        let core = core(vec![MockHttpRoute::new(
+            "GET",
+            "https://gitea.com/api/v1/repos/test/user-repo",
+            200,
+            r#"{ "id": 1234 }"#,
+        )]);
+
+        let repo = Repo::new("gitea:test/user-repo", std::path::PathBuf::from("/"));
+        assert!(
+            GiteaService::default()
+                .is_created(&core, &service(), &repo)
+                .await
+                .expect("No error should have been generated")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_is_created_no() {
+        let core = core(vec![MockHttpRoute::new(
+            "GET",
+            "https://gitea.com/api/v1/repos/test/user-repo",
+            404,
+            r#"{ "message": "Not Found" }"#,
+        )]);
+
+        let repo = Repo::new("gitea:test/user-repo", std::path::PathBuf::from("/"));
+        assert!(
+            !GiteaService::default()
+                .is_created(&core, &service(), &repo)
+                .await
+                .expect("No error should have been generated")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_move_same_namespace() {
+        let core = core(vec![MockHttpRoute::new(
+            "PATCH",
+            "https://gitea.com/api/v1/repos/test/user-repo",
+            200,
+            r#"{ "id": 1234 }"#,
+        )]);
+
+        let src = Repo::new("gitea:test/user-repo", std::path::PathBuf::from("/"));
+        let dest = Repo::new("gitea:test/new-name", std::path::PathBuf::from("/"));
+        GiteaService::default()
+            .move_repo(&core, &service(), &src, &dest)
+            .await
+            .expect("No error should have been generated");
+    }
+
+    #[tokio::test]
+    async fn test_move_different_namespace() {
+        let core = core(vec![
+            MockHttpRoute::new(
+                "POST",
+                "https://gitea.com/api/v1/repos/test/user-repo/transfer",
+                202,
+                r#"{ "id": 1234 }"#,
+            ),
+            MockHttpRoute::new(
+                "PATCH",
+                "https://gitea.com/api/v1/repos/other/user-repo",
+                200,
+                r#"{ "id": 1234 }"#,
+            ),
+        ]);
+
+        let src = Repo::new("gitea:test/user-repo", std::path::PathBuf::from("/"));
+        let dest = Repo::new("gitea:other/new-name", std::path::PathBuf::from("/"));
+        GiteaService::default()
+            .move_repo(&core, &service(), &src, &dest)
+            .await
+            .expect("No error should have been generated");
+    }
+
+    #[tokio::test]
+    async fn test_fork_repo() {
+        let core = core(vec![
+            MockHttpRoute::new(
+                "GET",
+                "https://gitea.com/api/v1/user",
+                200,
+                r#"{ "login": "test" }"#,
+            ),
+            MockHttpRoute::new(
+                "POST",
+                "https://gitea.com/api/v1/repos/other/user-repo/forks",
+                202,
+                r#"{ "id": 1234 }"#,
+            ),
+        ]);
+
+        let src = Repo::new("gitea:other/user-repo", std::path::PathBuf::from("/"));
+        let dest = Repo::new("gitea:test/user-repo", std::path::PathBuf::from("/"));
+        GiteaService::default()
+            .fork_repo(&core, &service(), &src, &dest, true)
+            .await
+            .expect("No error should have been generated");
+    }
+}

--- a/src/online/service/github.rs
+++ b/src/online/service/github.rs
@@ -8,7 +8,6 @@ use reqwest::{Method, Request, StatusCode, Url};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing_batteries::prelude::*;
 
 #[derive(Default)]
 pub struct GitHubService {}

--- a/src/online/service/gitlab.rs
+++ b/src/online/service/gitlab.rs
@@ -1,0 +1,668 @@
+use super::*;
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
+use reqwest::{Method, StatusCode};
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+#[derive(Default)]
+pub struct GitLabService {}
+
+#[async_trait]
+impl OnlineService for GitLabService {
+    fn handles(&self, service: &Service) -> bool {
+        service
+            .api
+            .as_ref()
+            .map(|api| api.kind == "GitLab/v4")
+            .unwrap_or(false)
+    }
+
+    fn auth_instructions(&self) -> String {
+        r#"
+Create a new Personal Access Token with the 'api' scope at https://gitlab.com/-/user_settings/personal_access_tokens
+Configure it with the following:
+  - Scopes: api
+
+For a self-managed GitLab instance, replace the domain above with your instance's URL (for example https://gitlab.example.com/-/user_settings/personal_access_tokens)."#
+            .trim()
+            .into()
+    }
+
+    async fn test(&self, core: &Core, service: &Service) -> Result<(), human_errors::Error> {
+        self.get_current_username(core, service).await?;
+        Ok(())
+    }
+
+    #[tracing::instrument(err, skip(self, core))]
+    async fn is_created(
+        &self,
+        core: &Core,
+        service: &Service,
+        repo: &Repo,
+    ) -> Result<bool, human_errors::Error> {
+        let uri = format!(
+            "{}/projects/{}",
+            self.api_url(service),
+            encode_path(&repo.get_full_name())
+        );
+
+        let resp: Result<ProjectResponse, GitLabErrorResponse> = self
+            .make_request(
+                core,
+                service,
+                Method::GET,
+                &uri,
+                Vec::new(),
+                vec![StatusCode::OK],
+            )
+            .await?;
+
+        match resp {
+            Ok(_) => Ok(true),
+            Err(e) if e.http_status_code == StatusCode::NOT_FOUND => Ok(false),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    #[tracing::instrument(err, skip(self, core))]
+    async fn ensure_created(
+        &self,
+        core: &Core,
+        service: &Service,
+        repo: &Repo,
+    ) -> Result<(), human_errors::Error> {
+        let current_user = self.get_current_username(core, service).await?;
+
+        let visibility = if core
+            .config()
+            .get_features()
+            .has(features::CREATE_REMOTE_PRIVATE)
+        {
+            "private"
+        } else {
+            "public"
+        };
+
+        let mut body_json = json!({
+            "name": repo.get_name(),
+            "path": repo.get_name(),
+            "visibility": visibility,
+        });
+
+        // When the repository lives under a namespace which isn't the current user's
+        // personal namespace, we need to resolve the numeric namespace ID so that GitLab
+        // knows where to create the new project.
+        if !repo.namespace.eq_ignore_ascii_case(&current_user) {
+            let namespace_id = self
+                .get_namespace_id(core, service, &repo.namespace)
+                .await?;
+            if let Value::Object(map) = &mut body_json {
+                map.insert("namespace_id".into(), json!(namespace_id));
+            }
+        }
+
+        let req_body = serde_json::to_vec(&body_json).wrap_system_err(
+            "Failed to serialize repository information for submission to GitLab as part of repo creation.", &[
+                "Please report this issue to us by creating a new GitHub issue.",
+                "Try creating your repository with `git-tool new --no-create-remote` and then pushing it to GitLab manually."
+            ])?;
+
+        let uri = format!("{}/projects", self.api_url(service));
+        let resp: Result<ProjectResponse, GitLabErrorResponse> = self
+            .make_request(
+                core,
+                service,
+                Method::POST,
+                &uri,
+                req_body,
+                vec![StatusCode::CREATED],
+            )
+            .await?;
+
+        match resp {
+            Ok(_) => Ok(()),
+            Err(e) if e.already_exists() => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    #[tracing::instrument(err, skip(self, core))]
+    async fn move_repo(
+        &self,
+        core: &Core,
+        service: &Service,
+        source: &Repo,
+        destination: &Repo,
+    ) -> Result<(), human_errors::Error> {
+        if source
+            .namespace
+            .eq_ignore_ascii_case(&destination.namespace)
+        {
+            // A move within the same namespace is a simple rename of the project's path.
+            self.rename_project(core, service, &source.get_full_name(), &destination.name)
+                .await?;
+        } else {
+            // Moving between namespaces requires a transfer, which preserves the project's
+            // path. If the caller also wants to rename the project we follow up with a
+            // rename once the transfer has completed.
+            let uri = format!(
+                "{}/projects/{}/transfer",
+                self.api_url(service),
+                encode_path(&source.get_full_name())
+            );
+
+            let body = serde_json::to_vec(&json!({
+                "namespace": destination.namespace,
+            }))
+            .wrap_system_err(
+                "Failed to serialize repository information for submission to GitLab as part of repo transfer.", &[
+                    "Please report this issue to us by creating a new GitHub issue.",
+                    "Try transferring the repository manually on GitLab using the repository settings page."
+                ])?;
+
+            let resp: Result<ProjectResponse, GitLabErrorResponse> = self
+                .make_request(core, service, Method::PUT, &uri, body, vec![StatusCode::OK])
+                .await?;
+
+            if let Err(e) = resp {
+                return Err(e.into());
+            }
+
+            if !source.name.eq_ignore_ascii_case(&destination.name) {
+                let transferred = format!("{}/{}", destination.namespace, source.name);
+                self.rename_project(core, service, &transferred, &destination.name)
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tracing::instrument(err, skip(self, core))]
+    async fn fork_repo(
+        &self,
+        core: &Core,
+        service: &Service,
+        source: &Repo,
+        destination: &Repo,
+        _default_branch_only: bool,
+    ) -> Result<(), human_errors::Error> {
+        let uri = format!(
+            "{}/projects/{}/fork",
+            self.api_url(service),
+            encode_path(&source.get_full_name())
+        );
+
+        let body = serde_json::to_vec(&json!({
+            "namespace_path": destination.namespace,
+            "name": destination.name,
+            "path": destination.name,
+        }))
+        .wrap_system_err(
+            "Failed to serialize repository information for submission to GitLab as part of repo fork.", &[
+                "Please report this issue to us by creating a new GitHub issue.",
+                "Try forking the repository manually on GitLab using the repository page."
+            ])?;
+
+        let resp: Result<ProjectResponse, GitLabErrorResponse> = self
+            .make_request(
+                core,
+                service,
+                Method::POST,
+                &uri,
+                body,
+                vec![StatusCode::CREATED, StatusCode::OK],
+            )
+            .await?;
+
+        match resp {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+impl GitLabService {
+    fn api_url(&self, service: &Service) -> String {
+        service
+            .api
+            .as_ref()
+            .map(|api| api.url.trim_end_matches('/').to_string())
+            .unwrap_or_default()
+    }
+
+    async fn get_current_username(
+        &self,
+        core: &Core,
+        service: &Service,
+    ) -> Result<String, human_errors::Error> {
+        let uri = format!("{}/user", self.api_url(service));
+        let user: Result<UserProfile, GitLabErrorResponse> = self
+            .make_request(
+                core,
+                service,
+                Method::GET,
+                &uri,
+                Vec::new(),
+                vec![StatusCode::OK],
+            )
+            .await?;
+
+        match user {
+            Ok(user) => Ok(user.username),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn get_namespace_id(
+        &self,
+        core: &Core,
+        service: &Service,
+        namespace: &str,
+    ) -> Result<u64, human_errors::Error> {
+        let uri = format!(
+            "{}/namespaces/{}",
+            self.api_url(service),
+            encode_path(namespace)
+        );
+
+        let resp: Result<NamespaceResponse, GitLabErrorResponse> = self
+            .make_request(
+                core,
+                service,
+                Method::GET,
+                &uri,
+                Vec::new(),
+                vec![StatusCode::OK],
+            )
+            .await?;
+
+        match resp {
+            Ok(ns) => Ok(ns.id),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn rename_project(
+        &self,
+        core: &Core,
+        service: &Service,
+        full_name: &str,
+        new_name: &str,
+    ) -> Result<(), human_errors::Error> {
+        let uri = format!(
+            "{}/projects/{}",
+            self.api_url(service),
+            encode_path(full_name)
+        );
+
+        let body = serde_json::to_vec(&json!({
+            "name": new_name,
+            "path": new_name,
+        }))
+        .wrap_system_err(
+            "Failed to serialize repository information for submission to GitLab as part of repo rename.", &[
+                "Please report this issue to us by creating a new GitHub issue.",
+                "Try renaming the repository manually on GitLab using the repository settings page."
+            ])?;
+
+        let resp: Result<ProjectResponse, GitLabErrorResponse> = self
+            .make_request(core, service, Method::PUT, &uri, body, vec![StatusCode::OK])
+            .await?;
+
+        match resp {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn make_request<B: Into<reqwest::Body> + Clone, T: DeserializeOwned>(
+        &self,
+        core: &Core,
+        service: &Service,
+        method: Method,
+        uri: &str,
+        body: B,
+        acceptable: Vec<StatusCode>,
+    ) -> Result<Result<T, GitLabErrorResponse>, human_errors::Error> {
+        let token = core.keychain().get_token(&service.name)?;
+
+        let headers = vec![
+            ("Accept", "application/json".to_string()),
+            ("Content-Type", "application/json".to_string()),
+            ("Authorization", format!("Bearer {token}")),
+        ];
+
+        let (status, bytes) = request_with_retry(core, method, uri, &headers, body).await?;
+
+        if acceptable.contains(&status) {
+            let result = serde_json::from_slice(&bytes).wrap_system_err(
+                "We could not deserialize the response from GitLab because it didn't match the expected response format.",
+                &["Please report this issue to us on GitHub with the trace ID for the command you were running so that we can investigate."],
+            )?;
+
+            return Ok(Ok(result));
+        }
+
+        let mut result: GitLabErrorResponse = serde_json::from_slice(&bytes).unwrap_or_default();
+        result.http_status_code = status;
+        Ok(Err(result))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct UserProfile {
+    pub username: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct NamespaceResponse {
+    pub id: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct ProjectResponse {
+    pub id: u64,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GitLabErrorResponse {
+    #[serde(skip)]
+    pub http_status_code: StatusCode,
+
+    #[serde(default)]
+    pub message: Value,
+
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+impl GitLabErrorResponse {
+    fn message_text(&self) -> String {
+        if let Some(err) = &self.error {
+            return err.clone();
+        }
+
+        match &self.message {
+            Value::String(s) => s.clone(),
+            Value::Null => String::new(),
+            other => other.to_string(),
+        }
+    }
+
+    /// Determines whether the error returned by GitLab indicates that the project
+    /// already exists (GitLab responds with a 400 whose validation errors mention
+    /// that the name or path have already been taken).
+    fn already_exists(&self) -> bool {
+        self.http_status_code == StatusCode::BAD_REQUEST
+            && self.message_text().contains("has already been taken")
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<Error> for GitLabErrorResponse {
+    fn into(self) -> Error {
+        match self.http_status_code {
+            StatusCode::UNAUTHORIZED => human_errors::user(
+                "You have not provided a valid authentication token for GitLab.",
+                &[
+                    "Generate a valid Personal Access Token with the `api` scope and add it using `git-tool auth <service>`.",
+                ],
+            ),
+            StatusCode::FORBIDDEN => human_errors::wrap_user(
+                format!("{self:?}"),
+                format!(
+                    "You do not have permission to perform this action on GitLab: {}",
+                    self.message_text()
+                ),
+                &[
+                    "Check that your access token has the `api` scope and that you have permission to manage this project or group.",
+                ],
+            ),
+            StatusCode::NOT_FOUND => human_errors::wrap_user(
+                format!("{self:?}"),
+                "We could not find the GitLab group or project you specified.",
+                &[
+                    "Check that you have specified the correct group or user in the repository name and try again.",
+                ],
+            ),
+            StatusCode::TOO_MANY_REQUESTS => human_errors::user(
+                "GitLab has rate limited requests from your IP address.",
+                &["Please wait until GitLab removes this rate limit before trying again."],
+            ),
+            status => human_errors::wrap_system(
+                format!("{self:?}"),
+                format!(
+                    "Received an HTTP {} {} response from GitLab: {}",
+                    status.as_u16(),
+                    status.canonical_reason().unwrap_or_default(),
+                    self.message_text()
+                ),
+                &[
+                    "Please read the error message below and decide if there is something you can do to fix the problem, or report it to us on GitHub.",
+                ],
+            ),
+        }
+    }
+}
+
+fn encode_path(value: &str) -> String {
+    // GitLab identifies projects and groups by their URL-encoded path, where the `/`
+    // separators are encoded (for example `group/project` becomes `group%2Fproject`).
+    // We encode every reserved character but preserve the unreserved characters
+    // (`-`, `.`, `_`, `~`) so that the resulting identifiers stay readable and match
+    // exactly what GitLab expects.
+    const PATH_ENCODE: &AsciiSet = &NON_ALPHANUMERIC
+        .remove(b'-')
+        .remove(b'.')
+        .remove(b'_')
+        .remove(b'~');
+
+    utf8_percent_encode(value, PATH_ENCODE).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockall::predicate::eq;
+
+    fn service() -> Service {
+        Service {
+            name: "gl".into(),
+            website: "https://gitlab.com/{{ .Repo.FullName }}".into(),
+            git_url: "git@gitlab.com:{{ .Repo.FullName }}.git".into(),
+            pattern: "*/*".into(),
+            api: Some(ServiceAPI {
+                kind: "GitLab/v4".into(),
+                url: "https://gitlab.com/api/v4".into(),
+            }),
+        }
+    }
+
+    fn core(mocks: Vec<MockHttpRoute>) -> Core {
+        Core::builder()
+            .with_default_config()
+            .with_mock_keychain(|mock| {
+                mock.expect_get_token()
+                    .with(eq("gl"))
+                    .returning(|_| Ok("test_token".into()));
+            })
+            .with_mock_http_client(mocks)
+            .build()
+    }
+
+    #[tokio::test]
+    async fn test_create_user_repo() {
+        let core = core(vec![
+            MockHttpRoute::new(
+                "GET",
+                "https://gitlab.com/api/v4/user",
+                200,
+                r#"{ "username": "test" }"#,
+            ),
+            MockHttpRoute::new(
+                "POST",
+                "https://gitlab.com/api/v4/projects",
+                201,
+                r#"{ "id": 1234 }"#,
+            ),
+        ]);
+
+        let repo = Repo::new("gl:test/user-repo", std::path::PathBuf::from("/"));
+        GitLabService::default()
+            .ensure_created(&core, &service(), &repo)
+            .await
+            .expect("No error should have been generated");
+    }
+
+    #[tokio::test]
+    async fn test_create_namespaced_repo() {
+        let core = core(vec![
+            MockHttpRoute::new(
+                "GET",
+                "https://gitlab.com/api/v4/user",
+                200,
+                r#"{ "username": "test" }"#,
+            ),
+            MockHttpRoute::new(
+                "GET",
+                "https://gitlab.com/api/v4/namespaces/mygroup",
+                200,
+                r#"{ "id": 42 }"#,
+            ),
+            MockHttpRoute::new(
+                "POST",
+                "https://gitlab.com/api/v4/projects",
+                201,
+                r#"{ "id": 1234 }"#,
+            ),
+        ]);
+
+        let repo = Repo::new("gl:mygroup/user-repo", std::path::PathBuf::from("/"));
+        GitLabService::default()
+            .ensure_created(&core, &service(), &repo)
+            .await
+            .expect("No error should have been generated");
+    }
+
+    #[tokio::test]
+    async fn test_create_repo_exists() {
+        let core = core(vec![
+            MockHttpRoute::new(
+                "GET",
+                "https://gitlab.com/api/v4/user",
+                200,
+                r#"{ "username": "test" }"#,
+            ),
+            MockHttpRoute::new(
+                "POST",
+                "https://gitlab.com/api/v4/projects",
+                400,
+                r#"{ "message": { "name": ["has already been taken"], "path": ["has already been taken"] } }"#,
+            ),
+        ]);
+
+        let repo = Repo::new("gl:test/user-repo", std::path::PathBuf::from("/"));
+        GitLabService::default()
+            .ensure_created(&core, &service(), &repo)
+            .await
+            .expect("No error should have been generated");
+    }
+
+    #[tokio::test]
+    async fn test_is_created_yes() {
+        let core = core(vec![MockHttpRoute::new(
+            "GET",
+            "https://gitlab.com/api/v4/projects/test%2Fuser-repo",
+            200,
+            r#"{ "id": 1234 }"#,
+        )]);
+
+        let repo = Repo::new("gl:test/user-repo", std::path::PathBuf::from("/"));
+        assert!(
+            GitLabService::default()
+                .is_created(&core, &service(), &repo)
+                .await
+                .expect("No error should have been generated")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_is_created_no() {
+        let core = core(vec![MockHttpRoute::new(
+            "GET",
+            "https://gitlab.com/api/v4/projects/test%2Fuser-repo",
+            404,
+            r#"{ "message": "404 Project Not Found" }"#,
+        )]);
+
+        let repo = Repo::new("gl:test/user-repo", std::path::PathBuf::from("/"));
+        assert!(
+            !GitLabService::default()
+                .is_created(&core, &service(), &repo)
+                .await
+                .expect("No error should have been generated")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_move_same_namespace() {
+        let core = core(vec![MockHttpRoute::new(
+            "PUT",
+            "https://gitlab.com/api/v4/projects/test%2Fuser-repo",
+            200,
+            r#"{ "id": 1234 }"#,
+        )]);
+
+        let src = Repo::new("gl:test/user-repo", std::path::PathBuf::from("/"));
+        let dest = Repo::new("gl:test/new-name", std::path::PathBuf::from("/"));
+        GitLabService::default()
+            .move_repo(&core, &service(), &src, &dest)
+            .await
+            .expect("No error should have been generated");
+    }
+
+    #[tokio::test]
+    async fn test_move_different_namespace() {
+        let core = core(vec![
+            MockHttpRoute::new(
+                "PUT",
+                "https://gitlab.com/api/v4/projects/test%2Fuser-repo/transfer",
+                200,
+                r#"{ "id": 1234 }"#,
+            ),
+            MockHttpRoute::new(
+                "PUT",
+                "https://gitlab.com/api/v4/projects/other%2Fuser-repo",
+                200,
+                r#"{ "id": 1234 }"#,
+            ),
+        ]);
+
+        let src = Repo::new("gl:test/user-repo", std::path::PathBuf::from("/"));
+        let dest = Repo::new("gl:other/new-name", std::path::PathBuf::from("/"));
+        GitLabService::default()
+            .move_repo(&core, &service(), &src, &dest)
+            .await
+            .expect("No error should have been generated");
+    }
+
+    #[tokio::test]
+    async fn test_fork_repo() {
+        let core = core(vec![MockHttpRoute::new(
+            "POST",
+            "https://gitlab.com/api/v4/projects/test%2Fuser-repo/fork",
+            201,
+            r#"{ "id": 1234 }"#,
+        )]);
+
+        let src = Repo::new("gl:test/user-repo", std::path::PathBuf::from("/"));
+        let dest = Repo::new("gl:me/user-repo", std::path::PathBuf::from("/"));
+        GitLabService::default()
+            .fork_repo(&core, &service(), &src, &dest, true)
+            .await
+            .expect("No error should have been generated");
+    }
+}

--- a/src/online/service/mod.rs
+++ b/src/online/service/mod.rs
@@ -1,8 +1,16 @@
 use crate::engine::*;
+use crate::errors::HumanErrorResultExt;
 use async_trait::async_trait;
+use human_errors::ResultExt;
+use reqwest::{Method, Request, StatusCode, Url};
 use std::sync::Arc;
+use std::time::Duration;
+use tracing_batteries::prelude::*;
 
+pub mod bitbucket;
+pub mod gitea;
 pub mod github;
+pub mod gitlab;
 
 #[async_trait]
 pub trait OnlineService: Send + Sync {
@@ -42,5 +50,91 @@ pub trait OnlineService: Send + Sync {
 
 #[allow(dead_code)]
 pub fn services() -> Vec<Arc<dyn OnlineService>> {
-    vec![Arc::new(github::GitHubService::default())]
+    vec![
+        Arc::new(github::GitHubService::default()),
+        Arc::new(gitlab::GitLabService::default()),
+        Arc::new(gitea::GiteaService::default()),
+        Arc::new(bitbucket::BitBucketService::default()),
+    ]
+}
+
+/// Sends an HTTP request to a remote Git hosting service, transparently retrying
+/// requests which fail with a transient error (network failures, rate limiting,
+/// or server errors) up to a small number of times.
+///
+/// The caller is responsible for providing all request headers (including the
+/// `Accept` and `Authorization` headers) and for interpreting the response body
+/// based on the returned [`StatusCode`]. The `User-Agent` header is added
+/// automatically.
+#[allow(dead_code)]
+pub(crate) async fn request_with_retry<B: Into<reqwest::Body> + Clone>(
+    core: &Core,
+    method: Method,
+    uri: &str,
+    headers: &[(&'static str, String)],
+    body: B,
+) -> Result<(StatusCode, Vec<u8>), human_errors::Error> {
+    let url: Url = uri.parse().wrap_system_err(
+        format!("Unable to parse the API URL '{uri}'."),
+        &["Please report this error to us by opening an issue on GitHub."],
+    )?;
+
+    let mut remaining_attempts = 3;
+    let retryable = [
+        StatusCode::TOO_MANY_REQUESTS,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        StatusCode::BAD_GATEWAY,
+        StatusCode::SERVICE_UNAVAILABLE,
+    ];
+
+    loop {
+        remaining_attempts -= 1;
+
+        let mut req = Request::new(method.clone(), url.clone());
+        *req.body_mut() = Some(body.clone().into());
+
+        let req_headers = req.headers_mut();
+        req_headers.append(
+            "User-Agent",
+            version!("Git-Tool/v").parse().to_human_error()?,
+        );
+
+        for (name, value) in headers {
+            req_headers.append(*name, value.parse().to_human_error()?);
+        }
+
+        match core.http_client().request(req).await {
+            Ok(resp) if remaining_attempts > 0 && retryable.contains(&resp.status()) => {
+                warn!(
+                    "API request failed with status code {}. Retrying...",
+                    resp.status()
+                );
+
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                continue;
+            }
+            Ok(resp) => {
+                let status = resp.status();
+                let bytes = resp.bytes().await.wrap_system_err(
+                    format!(
+                        "We received an HTTP {} {} status code from the server and couldn't read the response body.",
+                        status.as_u16(),
+                        status.canonical_reason().unwrap_or("Unknown")
+                    ),
+                    &["The service might be having reliability difficulties at the moment, please try again later."],
+                )?;
+
+                return Ok((status, bytes.to_vec()));
+            }
+            Err(error) if remaining_attempts > 0 => {
+                warn!("API request failed with error {}. Retrying...", error);
+
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                continue;
+            }
+            Err(error) => {
+                return Err(error);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Add support for creating, forking, renaming and moving repositories on GitLab, Gitea/Forgejo and BitBucket, extending the online-service integration that previously only supported GitHub.

## What's new

Three new `OnlineService` implementations, each mirroring the existing GitHub behaviour and providing platform-specific access-token instructions:

- **GitLab** (`GitLab/v4`) — Bearer auth against the v4 REST API. Creates projects under the current user or a resolved group namespace, checks existence, renames within a namespace, transfers (with optional rename) across namespaces, and forks. Works with self-managed instances by pointing `api.url` at `https://gitlab.example.com/api/v4`.
- **Gitea / Forgejo / Codeberg** (`Gitea/v1`) — `token` auth against the v1 API. User/org repository creation, existence checks, transfer + rename, and forking.
- **BitBucket Cloud** (`BitBucket/2.0`) — automatically uses HTTP Basic auth for `username:app_password` credentials or Bearer auth for standalone access tokens. Supports creation, same-workspace rename and forking; cross-workspace moves return a clear error since the API does not support them.

## Supporting changes

- Added a shared `request_with_retry` helper that transparently retries transient failures (HTTP 429/5xx and network errors), used by all three new services.
- Registered the new services and added `api` blocks to the `gitlab`, `gitea`, `codeberg` and `bitbucket` registry definitions so they light up via `gt config add`.
- Documented the newly supported API kinds in `docs/config/services.md`.

## Testing

- Each platform has unit-test coverage for create, existence (yes/no), move/rename and fork flows, plus BitBucket's auth-header selection and cross-workspace error path.
- `cargo test`, `cargo fmt --check` and `cargo clippy --all-targets --all-features` all pass locally.