### PR TITLE
test: Expand fuzz coverage with registry, worktree and gitignore targets

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -24,11 +24,14 @@ jobs:
           - completion
           - config
           - git_operations
+          - gitignore
           - identifier
+          - registry
           - repo_config
           - search
           - tasks
           - templates
+          - worktree
 
     steps:
       - uses: actions/checkout@v7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,5 +92,12 @@ telemetry = []
 # to complex failure modes.
 pure-tests = []
 
+[lints.rust]
+# `fuzzing` is set by cargo-afl (afl.rs) when building fuzz targets. Declaring it
+# here keeps normal `cargo build`/`cargo test` runs free of unexpected-cfg
+# warnings for the `#[cfg(fuzzing)]`-gated helpers that are only exposed to the
+# fuzzing harness.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
+
 [profile.release]
 debug = true

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -5,13 +5,18 @@ publish = false
 edition = "2024"
 
 [dependencies]
-afl = "0.15"
+afl = "0.18"
 clap = "4.6.1"
 git-tool = { path = ".." }
 gotmpl = "0.6.1"
 serde_yaml = "0.9"
 tempfile = "3.27"
 tokio = { version = "1.52", features = ["rt-multi-thread"] }
+
+[lints.rust]
+# cargo-afl (afl.rs) sets `cfg(fuzzing)` when building fuzz targets; declaring it
+# here keeps plain `cargo` builds free of unexpected-cfg warnings.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
 
 [[bin]]
 name = "commands"
@@ -42,8 +47,22 @@ doc = false
 bench = false
 
 [[bin]]
+name = "gitignore"
+path = "fuzz_targets/gitignore.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "identifier"
 path = "fuzz_targets/identifier.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "registry"
+path = "fuzz_targets/registry.rs"
 test = false
 doc = false
 bench = false
@@ -72,6 +91,13 @@ bench = false
 [[bin]]
 name = "templates"
 path = "fuzz_targets/templates.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "worktree"
+path = "fuzz_targets/worktree.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/corpus/gitignore/managed-section
+++ b/fuzz/corpus/gitignore/managed-section
@@ -1,0 +1,10 @@
+# custom rules kept above the managed block
+*.log
+.env
+
+## -------- Managed by Git Tool -------- ##
+## Add any custom rules above this block ##
+## ------------------------------------- ##
+## @languages: rust,node
+/target
+node_modules/

--- a/fuzz/corpus/gitignore/no-section
+++ b/fuzz/corpus/gitignore/no-section
@@ -1,0 +1,3 @@
+*.log
+build/
+dist/

--- a/fuzz/corpus/registry/app-entry
+++ b/fuzz/corpus/registry/app-entry
@@ -1,0 +1,19 @@
+name: VSCode
+description: Launches Visual Studio Code in a project directory.
+configs:
+  - platform: linux
+    app:
+      name: code
+      command: code
+      args:
+        - "."
+  - platform: windows
+    app:
+      name: code
+      command: cmd.exe
+      args:
+        - "/Q"
+        - "/C"
+        - "code.cmd ."
+      environment:
+        - "EDITOR=code"

--- a/fuzz/corpus/registry/service-entry
+++ b/fuzz/corpus/registry/service-entry
@@ -1,0 +1,12 @@
+name: GitHub
+description: Adds support for managing GitHub repositories through Git-Tool.
+configs:
+  - platform: any
+    service:
+      name: gh
+      website: "https://github.com/{{ .Repo.FullName }}"
+      gitUrl: "git@github.com:{{ .Repo.FullName }}.git"
+      pattern: "*/*"
+      api:
+        kind: GitHub/v3
+        url: https://api.github.com

--- a/fuzz/corpus/worktree/detached
+++ b/fuzz/corpus/worktree/detached
@@ -1,0 +1,4 @@
+worktree /home/user/project
+HEAD 0123456789abcdef0123456789abcdef01234567
+detached
+

--- a/fuzz/corpus/worktree/two-worktrees
+++ b/fuzz/corpus/worktree/two-worktrees
@@ -1,0 +1,8 @@
+worktree /home/user/project
+HEAD 0123456789abcdef0123456789abcdef01234567
+branch refs/heads/main
+
+worktree /home/user/project-feature
+HEAD 89abcdef0123456789abcdef0123456789abcdef
+branch refs/heads/feature/example
+

--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -39,3 +39,30 @@ pub fn runtime() -> &'static tokio::runtime::Runtime {
             .expect("the fuzz runtime to initialize")
     })
 }
+
+/// Records the observed state (hashed from the provided fields) with IJON so
+/// that AFL++ treats reaching a previously-unseen state as new coverage. This
+/// helps the fuzzer explore stateful code paths — such as sequences of git
+/// branch operations — whose interesting behaviour is invisible to plain edge
+/// coverage. On non-fuzzing builds it is a no-op.
+pub fn record_state(fields: &[String]) {
+    #[cfg(fuzzing)]
+    {
+        let mut sorted: Vec<&String> = fields.iter().collect();
+        sorted.sort();
+
+        // FNV-style fold of the sorted field set into a single IJON state value.
+        let mut hash: u32 = 0;
+        for field in sorted {
+            for byte in field.bytes() {
+                hash = hash.wrapping_mul(31).wrapping_add(byte as u32);
+            }
+            hash = hash.wrapping_mul(31).wrapping_add(1);
+        }
+
+        afl::ijon_set!(hash);
+    }
+
+    #[cfg(not(fuzzing))]
+    let _ = fields;
+}

--- a/fuzz/fuzz_targets/git_operations.rs
+++ b/fuzz/fuzz_targets/git_operations.rs
@@ -28,9 +28,13 @@ fn main() {
                 }
 
                 assert!(temp.path().join(".git").is_dir());
-                git::git_branches(temp.path())
+                let branches = git::git_branches(temp.path())
                     .await
                     .expect("the initialized repository to remain queryable");
+
+                // Feed the current branch-set to IJON so AFL++ explores novel
+                // repository states rather than just newly-executed code edges.
+                common::record_state(&branches);
             }
         });
     });

--- a/fuzz/fuzz_targets/gitignore.rs
+++ b/fuzz/fuzz_targets/gitignore.rs
@@ -1,0 +1,20 @@
+use afl::fuzz;
+use git_tool::online::gitignore::parse_managed_section_fuzz;
+
+mod common;
+
+fn main() {
+    fuzz!(|data: &[u8]| {
+        let input = String::from_utf8_lossy(common::bounded_bytes(data)).into_owned();
+
+        // Parsing arbitrary .gitignore content must never panic or loop, and must
+        // be deterministic.
+        let parsed = parse_managed_section_fuzz(&input);
+        assert_eq!(parsed, parse_managed_section_fuzz(&input));
+
+        // Re-parsing the normalized rendering must also terminate cleanly.
+        if let Some(rendered) = parsed {
+            let _ = parse_managed_section_fuzz(&rendered);
+        }
+    });
+}

--- a/fuzz/fuzz_targets/registry.rs
+++ b/fuzz/fuzz_targets/registry.rs
@@ -1,0 +1,28 @@
+use afl::fuzz;
+use git_tool::online::registry::Entry;
+
+mod common;
+
+fn main() {
+    fuzz!(|data: &[u8]| {
+        let input = common::bounded_bytes(data);
+
+        // Mirrors how the file-backed and GitHub registries deserialize untrusted
+        // registry entries (`serde_yaml::from_slice`/`from_str::<Entry>`).
+        if let Ok(entry) = serde_yaml::from_slice::<Entry>(input) {
+            let canonical =
+                serde_yaml::to_string(&entry).expect("a parsed registry entry to serialize");
+            let reparsed: Entry =
+                serde_yaml::from_str(&canonical).expect("a serialized registry entry to parse");
+            let reserialized =
+                serde_yaml::to_string(&reparsed).expect("a reparsed registry entry to serialize");
+
+            let canonical_value: serde_yaml::Value = serde_yaml::from_str(&canonical)
+                .expect("a serialized registry entry to be valid YAML");
+            let reserialized_value: serde_yaml::Value = serde_yaml::from_str(&reserialized)
+                .expect("a reserialized registry entry to be valid YAML");
+
+            assert_eq!(canonical_value, reserialized_value);
+        }
+    });
+}

--- a/fuzz/fuzz_targets/tasks.rs
+++ b/fuzz/fuzz_targets/tasks.rs
@@ -49,9 +49,13 @@ fn main() {
                 }
 
                 assert!(temp.path().join(".git").is_dir());
-                git::git_branches(temp.path())
+                let branches = git::git_branches(temp.path())
                     .await
                     .expect("the task-managed repository to remain queryable");
+
+                // Feed the current branch-set to IJON so AFL++ explores novel
+                // repository states rather than just newly-executed code edges.
+                common::record_state(&branches);
             }
         });
     });

--- a/fuzz/fuzz_targets/worktree.rs
+++ b/fuzz/fuzz_targets/worktree.rs
@@ -1,0 +1,22 @@
+use afl::fuzz;
+use git_tool::git::parse_worktree_list_fuzz;
+
+mod common;
+
+fn main() {
+    fuzz!(|data: &[u8]| {
+        let input = String::from_utf8_lossy(common::bounded_bytes(data)).into_owned();
+
+        // Parsing arbitrary `git worktree list --porcelain` output must never
+        // panic, must terminate, and must be deterministic.
+        let worktrees = parse_worktree_list_fuzz(&input);
+        assert_eq!(worktrees, parse_worktree_list_fuzz(&input));
+
+        for worktree in &worktrees {
+            if let Some(branch) = &worktree.branch {
+                // The refs/heads/ prefix is always stripped from branch names.
+                assert!(!branch.starts_with("refs/heads/"));
+            }
+        }
+    });
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -35,6 +35,11 @@ pub use worktree::{
     Worktree, git_worktree_add, git_worktree_is_clean, git_worktree_list, git_worktree_remove,
 };
 
+// Only exposed to the fuzzing harness (cargo-afl sets `cfg(fuzzing)`), allowing
+// the `git worktree list --porcelain` parser to be fuzzed without invoking git.
+#[cfg(fuzzing)]
+pub use worktree::parse_worktree_list_fuzz;
+
 #[cfg(test)]
 pub use config::git_config_set;
 #[cfg(test)]

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -93,6 +93,21 @@ pub async fn git_worktree_list(repo: &path::Path) -> Result<Vec<Worktree>, human
     )
     .await?;
 
+    Ok(parse_worktree_list(&output)
+        .into_iter()
+        .map(|worktree| Worktree {
+            path: canonicalize_worktree_path(worktree.path),
+            ..worktree
+        })
+        .collect())
+}
+
+/// Parses the output of `git worktree list --porcelain` into [`Worktree`]
+/// entries. The returned paths are exactly as reported by git (they are
+/// canonicalized separately by [`git_worktree_list`]) so that this function
+/// performs no filesystem access and can be exercised against arbitrary input
+/// in isolation.
+fn parse_worktree_list(output: &str) -> Vec<Worktree> {
     let mut worktrees = Vec::new();
     let mut current_path: Option<path::PathBuf> = None;
     let mut current_branch: Option<String> = None;
@@ -114,7 +129,7 @@ pub async fn git_worktree_list(repo: &path::Path) -> Result<Vec<Worktree>, human
         } else if line.is_empty() {
             if let Some(path) = current_path.take() {
                 worktrees.push(Worktree {
-                    path: canonicalize_worktree_path(path),
+                    path,
                     branch: current_branch.take(),
                     head: current_head.take(),
                 });
@@ -126,13 +141,21 @@ pub async fn git_worktree_list(repo: &path::Path) -> Result<Vec<Worktree>, human
 
     if let Some(path) = current_path.take() {
         worktrees.push(Worktree {
-            path: canonicalize_worktree_path(path),
+            path,
             branch: current_branch.take(),
             head: current_head.take(),
         });
     }
 
-    Ok(worktrees)
+    worktrees
+}
+
+/// Exposes [`parse_worktree_list`] to the fuzzing harness. This is compiled only
+/// for `cfg(fuzzing)` builds (which cargo-afl sets automatically) so the
+/// porcelain parser can be fuzzed against arbitrary input without spawning git.
+#[cfg(fuzzing)]
+pub fn parse_worktree_list_fuzz(output: &str) -> Vec<Worktree> {
+    parse_worktree_list(output)
 }
 
 /// Normalizes a worktree path to its canonical form so that callers can compare

--- a/src/online/gitignore.rs
+++ b/src/online/gitignore.rs
@@ -159,6 +159,16 @@ impl GitIgnoreFileSection {
     }
 }
 
+/// Exposes the `.gitignore` managed-section parser to the fuzzing harness. This
+/// is compiled only for `cfg(fuzzing)` builds (which cargo-afl sets
+/// automatically) so the parser can be fuzzed against arbitrary input without
+/// performing any network requests. Returns the normalized rendering of the
+/// managed section when one is present.
+#[cfg(fuzzing)]
+pub fn parse_managed_section_fuzz(input: &str) -> Option<String> {
+    GitIgnoreFileSection::parse(input).map(Into::into)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Add three new AFL fuzz targets for previously-untested untrusted-input parsers,
and use IJON to guide exploration of the git branch state machine:

- registry: deserializes registry entries (Entry) the same way the file-backed
  and GitHub registries do.
- worktree: fuzzes the 'git worktree list --porcelain' parser, extracted into a
  pure parse_worktree_list exposed only under #[cfg(fuzzing)].
- gitignore: fuzzes the managed-section parser, exposed only under
  #[cfg(fuzzing)].

Bump afl 0.15 -> 0.18 to match cargo-afl and enable IJON, then feed the observed
branch-set into IJON (ijon_set!) from the git_operations and tasks targets so
AFL++ explores novel repository states rather than just code edges. Register
cfg(fuzzing) via [lints.rust] to keep normal builds warning-free.