### PR TITLE
tweak: Print the config path when running `gt config`

### DIFF
--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -301,7 +301,11 @@ impl Config {
 
         match &self.schema {
             Some(schema) => Ok(format!(
-                "# yaml-language-server: $schema={schema}\n{config}",
+                "# yaml-language-server: $schema={schema}\n# path: {}\n{config}",
+                self.config_file
+                    .as_ref()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|| "<unknown>".into()),
             )),
             None => Ok(config),
         }


### PR DESCRIPTION
This should make it a bit easier to debug where your config file is
being loaded from in cases where this might not be obvious.