### PR TITLE
Publish debug symbols on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,17 @@ jobs:
         run: |
           sentry-cli upload-dif -o sierra-softworks -p git-tool --include-sources ./target/${{ matrix.target }}/release/
 
+      # Publish debug symbols to symbols.sierrasoftworks.com as well (build ID
+      # derived server-side; authenticated with this workflow's OIDC id-token)
+      # so Pyroscope's symbolizer and debuggers can resolve frames by build
+      # ID. Runs before the strip below while the DWARF still exists; the
+      # action's own re-strip is then a no-op ahead of the full strip.
+      - name: Publish debug symbols
+        uses: SierraSoftworks/symbols@v1
+        with:
+          binary: target/${{ matrix.target }}/release/git-tool${{ matrix.extension }}
+          version: ${{ github.event.release.tag_name }}
+
       - name: Strip Debug Symbols
         run: |
           ${{ matrix.strip }} target/${{ matrix.target }}/release/git-tool${{ matrix.extension }}


### PR DESCRIPTION
Publishes debug symbols to symbols.sierrasoftworks.com on every release via SierraSoftworks/symbols@v1, following the pattern established in grey (SierraSoftworks/grey#1151, #1152). Uploads authenticate with the workflow's OIDC id-token (no secrets); the server derives the build ID from the file itself and auto-creates the project from the token's repository claim. On Linux/macOS the action re-strips the binary after splitting, so release assets keep their usual size.

Runs alongside the existing Sentry upload, before the Strip Debug Symbols step (the DWARF must still exist when the split happens). No build changes needed - the release profile already carries full debug info.

🤖 Generated with [Claude Code](https://claude.com/claude-code)